### PR TITLE
overhaul init.vim

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -13,7 +13,8 @@ shopt -s checkwinsize               # updates size of terminal after commands
 # * `autocd`, e.g. `**/qux` will enter `./foo/bar/baz/qux`
 # * Recursive globbing, e.g. `echo **/*.txt`
 for option in autocd globstar; do
-    shopt -s "$option" 2> /dev/null;
+
+    shopt -s "$option" 2> /dev/null || true
 done;
 
 if [ -f /etc/bash_completion ]; then

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -31,8 +31,6 @@ Plug 'tpope/vim-surround'
 Plug 'akinsho/toggleterm.nvim', {'tag' : '*'}
 call plug#end()
 
-lua require('leap').set_default_keymaps()
-
 " ============================================================================
 " LUA SETUP
 " ============================================================================
@@ -41,6 +39,7 @@ lua require('leap').set_default_keymaps()
 
 lua <<EOF
 -- Some Lua packages need to have their setup() function run.
+require('leap').set_default_keymaps()
 -- Override the ToggleTerm setting for vertical split terminal
 require('toggleterm').setup{
   size = function(term)

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -160,6 +160,9 @@ set hidden
 " Disable swap file creation. Keep enabled for huge files (:set swapfile)
 set noswapfile
 
+" Set the working directory to that of the opened file
+autocmd BufEnter * silent! lcd %:p:h
+
 
 " ----------------------------------------------------------------------------
 " Searching
@@ -173,6 +176,10 @@ set smartcase
 " Don't highlight search items by default
 set nohlsearch
 
+" When using :s/ to search and replace, this will give a live preview of the
+" proposed changes
+set inccommand=nosplit
+
 " ----------------------------------------------------------------------------
 " Tab completion settings
 " ----------------------------------------------------------------------------
@@ -185,8 +192,6 @@ set wildmode=list:full
 " Ignore these when autocompleting
 set wildignore=*.swp,*.bak,*.pyc,*.class
 
-set inccommand=nosplit  " when using :s/ to search and replace, this will give
-                        " a live preview of the proposed changes
 
 " ============================================================================
 " CUSTOM MAPPINGS
@@ -215,8 +220,6 @@ inoremap <leader>` <C-o>i```{r}<CR>```<Esc>O
 " for easily making Python lists out of pasted text.
 let @l = "I'A',j"
 
-" Set the working directory to that of the opened file
-autocmd BufEnter * silent! lcd %:p:h
 
 " ,ts to insert timestamp. Useful when writing logs
 inoremap <leader>ts <Esc>o<Esc>:r! date "+[\%Y-\%m-\%d \%H:\%M] "<CR>A

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -26,9 +26,11 @@ Plug 'junegunn/gv.vim'                    " Easily view and browse git history
 Plug 'samoshkin/vim-mergetool'            " Makes 3-way merge conflicts easier by only focusing on what needs to be manually edited
 Plug 'snakemake/snakemake', {'rtp': 'misc/vim', 'branch': 'main'} " Snakemake syntax and folding
 Plug 'ggandor/leap.nvim'                  " Jump around in a buffer with low mental effort
+Plug 'tpope/vim-surround'
 call plug#end()
 
 lua require('leap').set_default_keymaps()
+
 
 " ============================================================================
 " SETTINGS

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -192,45 +192,47 @@ set inccommand=nosplit  " when using :s/ to search and replace, this will give
 " ============================================================================
 " CUSTOM MAPPINGS
 " ============================================================================
-
-" re-map mapleader from \ to ,
+"
+" Re-map mapleader from \ to , (comma). Any time <leader> is used below, it
+" now means comma.
 let mapleader=","
 
 " ,H to toggle search highlight
 noremap <leader>H :set hlsearch!<CR>
 
-" Helper for pep8: cleans up trailing whitespace
+" ,W to clean up trailing whitespace in entire file
 nnoremap <leader>W :%s/\s\+$//<cr>:let @/=''<CR>
 
-" Refresh syntax highlighting
+" ,R to refresh syntax highlighting
 noremap <leader>R <Esc>:syntax sync fromstart<CR>
 inoremap <leader>R <C-o>:syntax sync fromstart<CR>
 
-" When editing RMarkdown, <leader>` creates a new fenced code block, ready to
-" type in. This works in insert or normal mode.
+" ,` (comma backtick) creates a new fenced RMarkdown code block, ready to type
+" in. This works in insert or normal mode.
 noremap <leader>` i```{r}<CR>```<Esc>O
 inoremap <leader>` <C-o>i```{r}<CR>```<Esc>O
 
-" 'Listify': for easily making Python lists out of pasted text.
+" @l will 'listify', surrounding with quotes and adding a trailing comma. Used
+" for easily making Python lists out of pasted text.
 let @l = "I'A',j"
 
 " Set the working directory to that of the opened file
 autocmd BufEnter * silent! lcd %:p:h
 
-" Insert timestamp. Useful when writing logs
-inoremap <leader>dt <Esc>o<Esc>:r! date "+[\%Y-\%m-\%d \%H:\%M] "<CR>A
-noremap <leader>dt <Esc>o<Esc>:r! date "+[\%Y-\%m-\%d \%H:\%M] "<CR>A
+" ,ts to insert timestamp. Useful when writing logs
+inoremap <leader>ts <Esc>o<Esc>:r! date "+[\%Y-\%m-\%d \%H:\%M] "<CR>A
+noremap <leader>ts <Esc>o<Esc>:r! date "+[\%Y-\%m-\%d \%H:\%M] "<CR>A
 
-" Insert an ReST-formatted title for today's date
+" ,d to insert a ReST-formatted title for today's date. Only works in ReST
+" files.
 autocmd FileType rst inoremap <leader>d <Esc>:r! date "+\%Y-\%m-\%d"<CR>A<CR>----------<CR>
 autocmd FileType rst noremap  <leader>d <Esc>:r! date "+\%Y-\%m-\%d"<CR>A<CR>----------<CR><Esc>
 
-" Same, but markdown header
+" ,d to insert a Markdown header for today's date. Only work in markdown files.
 autocmd FileType markdown inoremap <leader>d <Esc>:r! date "+\# \%Y-\%m-\%d"<CR>A
 autocmd FileType markdown noremap  <leader>d <Esc>:r! date "+\# \%Y-\%m-\%d"<CR>A
 
-
-" Fill the rest of the line with dashes
+" ,- to fill the rest of the line with dashes
 nnoremap <leader>- 80A-<Esc>d80<bar>
 
 " Hard-wrap at 80 columns. Mnemonic is md = 'markdown', a common filetype where
@@ -241,9 +243,9 @@ nnoremap <leader>md :set tw=80 fo+=t<CR>
 " the ,md above.
 nnoremap <leader>nd :set tw=80 fo-=t<CR>
 
-" Slightly saner behavior with long TSV lines. Leaves the cursor in the command
-" bar so you can type in an appropriate tab stop value. Mnemonic of <tab> should
-" be self-explanatory!
+" ,<TAB> for slightly saner behavior with long TSV lines. Leaves the cursor in
+" the command bar so you can type in an appropriate tab stop value. Mnemonic of
+" <tab> should be self-explanatory!
 nnoremap <leader><tab> :set nowrap tabstop=
 
 " ----------------------------------------------------------------------------
@@ -298,13 +300,14 @@ tnoremap <M-q> <C-\><C-n>:wincmd h<CR>
 " ============================================================================
 " FILE-TYPE SPECIFIC SETTINGS
 " ============================================================================
-autocmd! FileType html,xml set listchars-=tab:>. " disable tabs for other filetypes that don't care
-autocmd! FileType yaml,yml set shiftwidth=2 tabstop=2
-autocmd! FileType r,rmarkdown set shiftwidth=2 tabstop=2
+" disable tabs for other filetypes that don't care
+autocmd! FileType html,xml set listchars-=tab:>.
+
+" Override the shiftwidth and tabstops for some file types
+autocmd! FileType yaml,yml,r,rmarkdown,*.Rmd,*.rmd set shiftwidth=2 tabstop=2
 
 " Consider any files with these names to be Python
-au BufRead,BufNewFile Snakefile setfiletype python
-au BufRead,BufNewFile *.snakefile setfiletype python
+au BufRead,BufNewFile Snakefile,*.snakefile setfiletype python
 
 " ============================================================================
 " RELATIVE NUMBERING
@@ -335,7 +338,7 @@ let g:python_highlight_all = 1
 " ----------------------------------------------------------------------------
 " NERDTree
 " ----------------------------------------------------------------------------
-" Toggle NERDTree window
+" ,n to toggle NERDTree window
 nnoremap <leader>n :NERDTreeToggle<cr>
 
 " ----------------------------------------------------------------------------

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -256,6 +256,17 @@ syntax on
 " Enable detection, plugin , and indent for filetype
 filetype plugin indent on
 
+" Files will open with everything unfolded; fold commands like zc will
+" re-enable it.
+set nofoldenable
+
+" Support this many levels of nested folds. Use standard commands:
+"   zm to fold everything
+"   zn to unfold everything
+"   zc to fold section
+"   zi to unfold section
+set foldlevel=99
+
 " This gets backspace to work in some situations
 set backspace=indent,eol,start
 

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -213,12 +213,14 @@ call plug#end()
 " LUA SETUP
 " ============================================================================
 " The 'lua' command runs a line of Lua.
-" The 'lua <<EOF .... EOF' syntax embeds Lua in this vimscript file.
+" The 'lua <<EOF .... EOF' syntax allows multiple Lua lines.
+" Here, we run all of the Lua in one block.
 
 lua <<EOF
+
 -- Some Lua packages need to have their setup() function run.
-require('leap').set_default_keymaps()
 require("zenburn").setup()
+require('leap').set_default_keymaps()
 
 -- Override the ToggleTerm setting for vertical split terminal
 require('toggleterm').setup{
@@ -231,8 +233,10 @@ require('toggleterm').setup{
   end
 }
 
--- When yanking text, flash a highlight color over the yanked text
--- See `:help vim.highlight.on_yank()`
+-- Highlight when yanking text
+-- ---------------------------
+-- Flash a highlight color over the yanked text, see
+-- :help vim.highlight.on_yank()
 local highlight_group = vim.api.nvim_create_augroup('YankHighlight', { clear = true })
 vim.api.nvim_create_autocmd('TextYankPost', {
   callback = function()
@@ -255,9 +259,6 @@ filetype plugin indent on
 " This gets backspace to work in some situations
 set backspace=indent,eol,start
 
-" ----------------------------------------------------------------------------
-" Python-specific indentation handling. Use these by default.
-" ----------------------------------------------------------------------------
 " Number of spaces <Tab> represents
 set tabstop=4
 
@@ -273,9 +274,6 @@ set expandtab
 " Allows arrows and h/l to move to next line when at the end of one
 set whichwrap+=<,>,h,l
 
-" ----------------------------------------------------------------------------
-" Visual display settings
-" ----------------------------------------------------------------------------
 " Keep some lines above and below the cursor to keep context visible
 set scrolloff=3
 
@@ -295,54 +293,48 @@ set wrap
 set noshowmode
 
 " Allow mouse usage.
-" - Mouse-enabled motions: left-click to place the cursor. Type 'y' then
-"   left-click to yank from current cursor to where you next clicked.
+"   In addition to allowing clicking and scrolling:
+" - Support mouse-enabled motions: left-click to place the cursor. Type 'y'
+"   then left-click to yank from current cursor to where you next clicked.
 " - Drag the status-line or vertical separator to resize
 " - Double-click to select word; triple-click for line
 set mouse=a
 
-" Color the current line in insert mode
+" Color the current line in insert mode and remove color when leaving insert
+" mode
 :autocmd InsertEnter * set cul
-
-" Remove color when leaving insert mode
 :autocmd InsertLeave * set nocul
 
-" ----------------------------------------------------------------------------
-" Display nonprinting characters (tab characters and trailing spaces)
-" ----------------------------------------------------------------------------
-" Differentiating between tabs and spaces is extremely helpful in tricky
-" debugging situations.
+" Display nonprinting characters (tab characters and trailing spaces).
+"   Differentiating between tabs and spaces is extremely helpful in tricky
+"   debugging situations.
 "
-" With these settings <TAB> characters look like >••••.
+"   With these settings <TAB> characters look like >••••.
 "
-" Trailing spaces show up as dots like ∙∙∙∙∙.
+"   Trailing spaces show up as dots like ∙∙∙∙∙.
 "
-" The autocmds here mean that we only show the trailing spaces when we're
-" outside of insert mode, so that every space typed doesn't show up as
-" trailing.
+"   The autocmds here mean that we only show the trailing spaces when we're
+"   outside of insert mode, so that every space typed doesn't show up as
+"   trailing.
 "
-" When wrap is off, extends and precedes indicate that there's text offscreen
+"   When wrap is off, extends and precedes indicate that there's text offscreen
 :autocmd InsertEnter * set listchars=tab:>•
 :autocmd InsertLeave * set listchars=tab:>•,trail:∙,nbsp:•,extends:⟩,precedes:⟨
 
-" ----------------------------------------------------------------------------
 " Format options
-" ----------------------------------------------------------------------------
-"  Changes the behavior of various formatting
-"  See :h formatoptions
+"  Changes the behavior of various formatting; see :h formatoptions.
+"  Explanation of these options:
+"
+"    q: gq also formats comments
+"    r: insert comment leader after <Enter> in insert mode
+"    n: recognize numbered lists
+"    1: don't break a line after a 1-letter word
+"    c: autoformat comments
+"    o: automatically insert comment leader afer 'o' or 'O' in Normal mode.
+"       Use Ctrl-u to quickly delete it if you didn't want it.
+"    j: where it makes sense, remove a comment leader when joining lines
 set formatoptions=qrn1coj
-" q: gq also formats comments
-" r: insert comment leader after <Enter> in insert mode
-" n: recognize numbered lists
-" 1: don't break a line after a 1-letter word
-" c: autoformat comments
-" o: automatically insert comment leader afer 'o' or 'O' in Normal mode.
-"    Use Ctrl-u to quickly delete it if you didn't want it.
-" j: where it makes sense, remove a comment leader when joining lines
 
-" ----------------------------------------------------------------------------
-" General behavior
-" ----------------------------------------------------------------------------
 " Open a new buffer without having to save first
 set hidden
 
@@ -352,10 +344,6 @@ set noswapfile
 " Set the working directory to that of the opened file
 autocmd BufEnter * silent! lcd %:p:h
 
-
-" ----------------------------------------------------------------------------
-" Searching
-" ----------------------------------------------------------------------------
 " Ignore case when searching...
 set ignorecase
 
@@ -369,9 +357,6 @@ set nohlsearch
 " proposed changes
 set inccommand=nosplit
 
-" ----------------------------------------------------------------------------
-" Tab completion settings
-" ----------------------------------------------------------------------------
 " Make tab completion for files/buffers act like bash
 set wildmenu
 
@@ -386,8 +371,9 @@ set wildignore=*.swp,*.bak,*.pyc,*.class
 " CUSTOM MAPPINGS
 " ============================================================================
 "
-" Re-map mapleader from \ to , (comma). Any time <leader> is used below, it
-" now means comma.
+" Re-map leader from \ to , (comma). Any time <leader> is used below, it
+" now means comma. For succinctness, the comments in this document use
+" , instead of <leader>.
 let mapleader=","
 
 " ,H to toggle search highlight
@@ -409,7 +395,6 @@ inoremap <leader>` <C-o>i```{r}<CR>```<Esc>O
 " for easily making Python lists out of pasted text.
 let @l = "I'A',j"
 
-
 " ,ts to insert timestamp. Useful when writing logs
 inoremap <leader>ts <Esc>o<Esc>:r! date "+[\%Y-\%m-\%d \%H:\%M] "<CR>A
 noremap <leader>ts <Esc>o<Esc>:r! date "+[\%Y-\%m-\%d \%H:\%M] "<CR>A
@@ -419,7 +404,7 @@ noremap <leader>ts <Esc>o<Esc>:r! date "+[\%Y-\%m-\%d \%H:\%M] "<CR>A
 autocmd FileType rst inoremap <leader>d <Esc>:r! date "+\%Y-\%m-\%d"<CR>A<CR>----------<CR>
 autocmd FileType rst noremap  <leader>d <Esc>:r! date "+\%Y-\%m-\%d"<CR>A<CR>----------<CR><Esc>
 
-" ,d to insert a Markdown header for today's date. Only work in markdown files.
+" ,d to insert a Markdown header for today's date. Only works in markdown files.
 autocmd FileType markdown inoremap <leader>d <Esc>:r! date "+\# \%Y-\%m-\%d"<CR>A
 autocmd FileType markdown noremap  <leader>d <Esc>:r! date "+\# \%Y-\%m-\%d"<CR>A
 
@@ -438,6 +423,18 @@ nnoremap <leader>nd :set tw=80 fo-=ta<CR>
 " the command bar so you can type in an appropriate tab stop value. Mnemonic of
 " <tab> should be self-explanatory!
 nnoremap <leader><tab> :set nowrap tabstop=
+
+" ,r to toggle relative numbering -- useful for choosing how many lines to
+" delete, for example.
+function! NumberToggle()
+  if(&relativenumber == 1)
+    set nornu
+    set number
+  else
+    set rnu
+  endif
+endfunc
+nnoremap <leader>r :call NumberToggle()<cr>
 
 " ----------------------------------------------------------------------------
 " Buffer switching
@@ -482,10 +479,10 @@ noremap <silent> ,q :wincmd h<cr>
 tnoremap <silent> ,q <C-\><C-n>:wincmd h<cr>
 
 
-" ============================================================================
-" FILE-TYPE SPECIFIC SETTINGS
-" ============================================================================
-" disable tabs for other filetypes that don't care
+" ----------------------------------------------------------------------------
+" Filetype-specific settings
+" ----------------------------------------------------------------------------
+" Disable tab visibility for other filetypes that don't care
 autocmd! FileType html,xml set listchars-=tab:>.
 
 " Override the shiftwidth and tabstops for some file types
@@ -494,24 +491,9 @@ autocmd! FileType yaml,yml,r,rmarkdown,*.Rmd,*.rmd set shiftwidth=2 tabstop=2
 " Consider any files with these names to be Python
 au BufRead,BufNewFile Snakefile,*.snakefile setfiletype python
 
-" ============================================================================
-" RELATIVE NUMBERING
-" ============================================================================
-" ,r to enable relative numbering -- useful for choosing how many lines to
-" delete, for example.
-function! NumberToggle()
-  if(&relativenumber == 1)
-    set nornu
-    set number
-  else
-    set rnu
-  endif
-endfunc
-nnoremap <leader>r :call NumberToggle()<cr>
 
 " ============================================================================
 " PLUGIN SETTINGS AND MAPPINGS
-" Settings that require particular plugins to be installed. Grouped by plugin.
 " ============================================================================
 "
 " ----------------------------------------------------------------------------
@@ -520,11 +502,13 @@ nnoremap <leader>r :call NumberToggle()<cr>
 let g:python_highlight_space_errors = 0
 let g:python_highlight_all = 1
 
+
 " ----------------------------------------------------------------------------
 " NERDTree
 " ----------------------------------------------------------------------------
 " ,n to toggle NERDTree window
 nnoremap <leader>n :NERDTreeToggle<cr>
+
 
 " ----------------------------------------------------------------------------
 " ToggleTerm
@@ -582,14 +566,29 @@ nmap <leader>ko i<CR>```{r}<CR>knitr::opts_chunk$set(warning=FALSE, message=FALS
 
 
 " ----------------------------------------------------------------------------
-" powerline
+" vim-airline
 " ----------------------------------------------------------------------------
-let g:airline#extensions#tabline#enabled = 2
+" Enable the display of open buffers along the top, in neovim you can click
+" on them to select or use ,1 ,2 ,3 etc to switch to them. See :help
+" airline-tabline for more.
+let g:airline#extensions#tabline#enabled = 1
+
+" Show the buffer number next to the filename for easier switching. See :help
+" airline-tabline for more.
+let g:airline#extensions#tabline#buffer_nr_show = 1
+
+" When showing buffers in the top bufferline, show only the filename and not
+" the full path. See :help filename-modifiers for more info.
 let g:airline#extensions#tabline#fnamemod = ':t'
-let g:airline_theme = "powerlineish"
-set laststatus=2
+
+" See https://github.com/vim-airline/vim-airline/wiki/Screenshots to choose
+" other themes, and use :AirlineTheme <themename> to test live.
+let g:airline_theme = "hybridline"
+
+" If you are using a powerline-enabled font in your terminal application, set
+" this to 1. Otherwise set to 0. See :help airline-configuration for more.
 let g:airline_powerline_fonts = 1
-let g:bufferline_echo = 0
+
 
 " ----------------------------------------------------------------------------
 " vim-pandoc and vim-pandoc-syntax

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -2,34 +2,211 @@ call plug#begin()
 
 " Plugins come from GitHub. Plug 'username/repo' can be found at
 " https://github.com/user/repo.
-" These use vim-plug syntax.
 
-Plug 'vim-scripts/vis'                    " Operations in visual block mode respect selection
-Plug 'preservim/nerdcommenter'            " Comment large blocks of text
-Plug 'preservim/nerdtree'                 " File browser for vim <leader>n
-Plug 'vim-airline/vim-airline'            " Nice statusline. Install powerline fonts for full effect.
-Plug 'vim-airline/vim-airline-themes'     " Themes for the statusline
-Plug 'roxma/vim-tmux-clipboard'           " Copy yanked text from vim into tmux's clipboard and vice versa.
-Plug 'tmux-plugins/vim-tmux-focus-events' " Makes tmux and vim play nicer together.
-Plug 'vim-python/python-syntax'           " Sophisticated python syntax highlighting.
-Plug 'Vimjas/vim-python-pep8-indent'      " Indent python using pep8 recommendations
-Plug 'ervandew/supertab'                  " Autocomplete most things
-Plug 'tpope/vim-fugitive'                 " Run git from vim
-Plug 'chrisbra/vim-diff-enhanced'         " Provides additional diff algorithms
-Plug 'flazz/vim-colorschemes'             " Pile 'o colorschemes
-Plug 'felixhummel/setcolors.vim'          " Easily set colorschemes
-Plug 'vim-pandoc/vim-rmarkdown'           " Syntax highlighting for RMarkdown
-Plug 'vim-pandoc/vim-pandoc'              " Required for vim-rmarkdown
-Plug 'vim-pandoc/vim-pandoc-syntax'       " Required for vim-rmarkdown
-Plug 'dhruvasagar/vim-table-mode'         " Very easily make and work with markdown and restructured text tables
-Plug 'tmhedberg/SimpylFold'               " Nice folding for Python
-Plug 'junegunn/gv.vim'                    " Easily view and browse git history
-Plug 'samoshkin/vim-mergetool'            " Makes 3-way merge conflicts easier by only focusing on what needs to be manually edited
-Plug 'snakemake/snakemake', {'rtp': 'misc/vim', 'branch': 'main'} " Snakemake syntax and folding
-Plug 'ggandor/leap.nvim'                  " Jump around in a buffer with low mental effort
+" Vis
+" ---
+" Makes operations in visual block mode respect selection.
+"
+"   Use :B in front of commands (like s/) to make them use the current visual
+"   block selection, which perhaps surprisingly does not happen by default
+Plug 'vim-scripts/vis'
+
+" NERDCommenter
+" -------------
+" Comments blocks of text.
+"
+"   Use ,cc to comment visual selection
+"   Use ,ci to invert comment on selection
+"
+" See :help nerdcommenter for more
+Plug 'preservim/nerdcommenter'
+
+" NERDTree
+" --------
+" A file browser for vim.
+"
+"   Use ,n to toggle
+"
+" See :help NERDTree for much more
+Plug 'preservim/nerdtree'
+
+" vim-airline
+" -----------
+" Adds a nice statusline at the bottom and bufferline along the top.
+"
+" See the 'vim-airline' configuration section below. Use a powerline-enabled
+" font for full effect.
+Plug 'vim-airline/vim-airline'
+
+" vim-airline-themes
+" ------------------
+" Used for the statusline and bufferline provided by vim-airline.
+"
+" See https://github.com/vim-airline/vim-airline/wiki/Screenshots for themes,
+" and use :AirlineTheme <themename> to test them live.
+Plug 'vim-airline/vim-airline-themes'
+
+" vim-tmux-clipboard
+" ------------------
+" Automatically shares vim and tmux clipboards
+"
+" No added commands, but allows you to:
+"   - Yank text in vim, and paste it into a tmux terminal elsewhere.
+"   - Copy text anywhere in tmux, and paste it into any vim (that is also
+"   running this plugin)
+"
+" Need to add 'set -g focus-events on' to your .tmux.conf
+Plug 'roxma/vim-tmux-clipboard'
+
+" python-syntax
+" -------------
+" Improved python syntax highlighting (does not add any commands).
+Plug 'vim-python/python-syntax'
+
+" vim-python-pep8-indent
+" ----------------------
+" Indent python using pep8 recommendations (does not add any commands).
+Plug 'Vimjas/vim-python-pep8-indent'
+
+" Autocomplete most things.
+"
+Plug 'ervandew/supertab'
+
+" fugitive
+" --------
+" Run git interactively from vim.
+"
+"   Use :Git to get a text interface for incrementally making commits.
+"   Use = when over a filename to toggle visibility of its changes
+"   Use - in a chunk to stage it
+"   Use - on a selection to stage just that selection
+"   Use = over the staged section to toggle visibility of staged chunks
+"   Use - over staged lines or chunks to unstage them
+"   Use cc to commit, which opens a buffer to write in like normal git commits
+Plug 'tpope/vim-fugitive'
+
+" vim-diff-enhanced
+" -----------------
+" Provides additional diff algorithms
+"   See :help EnhancedDiff for more
+Plug 'chrisbra/vim-diff-enhanced'
+
+" vim-rmarkdown, vim-pandoc, vim-pandoc-syntax
+" --------------------------------------------
+" These three plugins jointly provide syntax highlighting for RMarkdown. This
+" allows R chunks to be formatted as R code.
+"
+" See vim-pandoc config section below.
+Plug 'vim-pandoc/vim-rmarkdown'
+Plug 'vim-pandoc/vim-pandoc'
+Plug 'vim-pandoc/vim-pandoc-syntax'
+
+" vim-table-mode
+" --------------
+" Very easily make and work with markdown and restructured text tables.
+"
+"   Use ,tm to toggle table mode (or use :TableModeEnable).
+"   Type the header, separated by |
+"   Use || on a new line to complete the header
+"   Type subsequent rows, fields delimited by |
+"   Complete the table with || above the first (header) line.
+"
+" Markdown or ReST format will be detected based on file type. See :help
+" table-mode for more.
+Plug 'dhruvasagar/vim-table-mode'
+
+" SimpylFold
+" ----------
+" Nice folding for Python. Folds functions and classes; leaves loops and
+" conditionals alone.
+"
+"   Use standard zc and zo to close and open folds
+"   Use standard zM and zN to fold and unfold all
+"
+" See :help SimpylFold for more.
+Plug 'tmhedberg/SimpylFold'
+
+" gv.vim
+" ------
+" Easily view and browse git history
+"
+"  Use :GV to open commit browser
+"  Use Enter on a commit to see it
+"  Use :GV in visual mode to see commits affecting those lines
+"  Use q to close the commit
+"  Use q again to close gv.vim
+Plug 'junegunn/gv.vim'
+
+" vim-mergetool
+" -------------
+" Makes 3-way merge conflicts easier by only focusing on what needs to be
+" manually edited. This requires the diff3 style following lines in your
+" .gitconfig:
+"
+"   [merge]
+"   conflictStyle = diff3
+"
+" Open a file with conflicts (like from a git merge). Then:
+"   Use :MergetoolStart to start this tool
+"   Either leave as-is, use :diffget to pull 'theirs', or manually edit each
+"   diff.
+"   When done, use :MergetoolStop
+"
+" See https://github.com/samoshkin/vim-mergetool for more.
+Plug 'samoshkin/vim-mergetool'
+
+" leap
+" ----
+" Jump around in a buffer with low mental effort
+"
+"   Look in the file where you want to go.
+"
+"   Use s to go below the current line
+"   Use S to go above the current line
+"
+"   After hitting s or S, type two of the characters you want to leap to. You
+"   will see highlighted letters pop up at all the possible destinations. Tap
+"   the highlighted letter of the one corresponding to where you want to jump.
+"
+" This works best when your eyes are looking where you want to jump.
+"
+" See :help leap for more.
+Plug 'ggandor/leap.nvim'
+
+" vim-surround
+" ------------
+" Change surrounding characters.
+"
+"   Use cs"' when inside something with double quotes to change " to '.
+"   Use ysiw" to add quotes around a word
+"
+" For a nice set of examples, see https://github.com/tpope/vim-surround, and
+" see :help surround for more.
 Plug 'tpope/vim-surround'
+
+" ToggleTerm
+" ----------
+" Easily interact with a terminal within vim.
+"
+" This opens a terminal and allows you to send lines to it. Very useful for
+" interactive Python and R work. See below ToggleTerm config for keymappings
+" configured here, but briefly:
+"
+"   Use ,t to open a terminal to the right
+"   Use ,w in normal mode to jump to the terminal
+"   Use ,q in terminal to jump back to text buffer
+"   Use ,gx on a selection to send it to the terminal
+"   Use ,gxx on a line to send it to the terminal
+"   Use ,cd to send an RMarkdown code chunk to the terminal (which is expected
+"   to be running an R interpreter)
+"
 Plug 'akinsho/toggleterm.nvim', {'tag' : '*'}
+
+" zenburn.nvim
+" ------------
+" The classic colorscheme, updated to support various widely-used plugins.
 Plug 'phha/zenburn.nvim'
+
 call plug#end()
 
 " ============================================================================

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -25,7 +25,10 @@ Plug 'tmhedberg/SimpylFold'               " Nice folding for Python
 Plug 'junegunn/gv.vim'                    " Easily view and browse git history
 Plug 'samoshkin/vim-mergetool'            " Makes 3-way merge conflicts easier by only focusing on what needs to be manually edited
 Plug 'snakemake/snakemake', {'rtp': 'misc/vim', 'branch': 'main'} " Snakemake syntax and folding
+Plug 'ggandor/leap.nvim'                  " Jump around in a buffer with low mental effort
 call plug#end()
+
+lua require('leap').set_default_keymaps()
 
 " ============================================================================
 " SETTINGS

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -202,11 +202,6 @@ Plug 'tpope/vim-surround'
 "
 Plug 'akinsho/toggleterm.nvim', {'tag' : '*'}
 
-" zenburn.nvim
-" ------------
-" The classic colorscheme, updated to support various widely-used plugins.
-Plug 'phha/zenburn.nvim'
-
 call plug#end()
 
 " ============================================================================
@@ -219,7 +214,6 @@ call plug#end()
 lua <<EOF
 
 -- Some Lua packages need to have their setup() function run.
-require("zenburn").setup()
 require('leap').set_default_keymaps()
 
 -- Override the ToggleTerm setting for vertical split terminal
@@ -252,6 +246,9 @@ EOF
 " ============================================================================
 " Syntax highlighting; also does an implicit filetype on
 syntax on
+
+" Set colorscheme here
+colorscheme zenburn
 
 " Enable detection, plugin , and indent for filetype
 filetype plugin indent on

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -51,6 +51,7 @@ set tabstop=4     " number of spaces <Tab> represents.  For Python.
 set shiftwidth=4  " number of spaces for indentation.  Same as tabstop. For Python.
 set smarttab      " at the beginning of the line, insert spaces according to shiftwidth
 set expandtab     " <Tab> inserts spaces, not '\t'
+set whichwrap+=<,>,h,l " allows arrows and h/l to move to next line when at the end of one
 
 " ----------------------------------------------------------------------------
 " Visual display settings

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -54,6 +54,16 @@ require('toggleterm').setup{
   end
 }
 
+-- When yanking text, flash a highlight color over the yanked text
+-- See `:help vim.highlight.on_yank()`
+local highlight_group = vim.api.nvim_create_augroup('YankHighlight', { clear = true })
+vim.api.nvim_create_autocmd('TextYankPost', {
+  callback = function()
+    vim.highlight.on_yank()
+  end,
+  group = highlight_group,
+  pattern = '*',
+})
 EOF
 
 " ============================================================================

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -1,7 +1,9 @@
 call plug#begin()
 
-" PLUGIN SETTINGS section.
-"
+" Plugins come from GitHub. Plug 'username/repo' can be found at
+" https://github.com/user/repo.
+" These use vim-plug syntax.
+
 Plug 'vim-scripts/vis'                    " Operations in visual block mode respect selection
 Plug 'preservim/nerdcommenter'            " Comment large blocks of text
 Plug 'preservim/nerdtree'                 " File browser for vim <Leader>n
@@ -35,78 +37,134 @@ lua require('leap').set_default_keymaps()
 " ============================================================================
 " SETTINGS
 " ============================================================================
-" ----------------------------------------------------------------------------
-" Syntax and file types
-" ----------------------------------------------------------------------------
-syntax on                      " Syntax highlighting; also does an implicit filetype on
-filetype plugin indent on      " Enable detection, plugin , and indent for filetype
-set backspace=indent,eol,start " This gets backspace to work in some situations
+" Syntax highlighting; also does an implicit filetype on
+syntax on
+
+" Enable detection, plugin , and indent for filetype
+filetype plugin indent on
+
+" This gets backspace to work in some situations
+set backspace=indent,eol,start
 
 " ----------------------------------------------------------------------------
 " Python-specific indentation handling. Use these by default.
 " ----------------------------------------------------------------------------
-set foldlevel=99  " go deep
-set autoindent    " maintain indentation from prev line
-set tabstop=4     " number of spaces <Tab> represents.  For Python.
-set shiftwidth=4  " number of spaces for indentation.  Same as tabstop. For Python.
-set smarttab      " at the beginning of the line, insert spaces according to shiftwidth
-set expandtab     " <Tab> inserts spaces, not '\t'
-set whichwrap+=<,>,h,l " allows arrows and h/l to move to next line when at the end of one
+" Number of spaces <Tab> represents
+set tabstop=4
+
+" Number of spaces for indentation. Same as tabstop.
+set shiftwidth=4
+
+" At the beginning of the line, insert spaces according to shiftwidth
+set smarttab
+
+" <Tab> inserts spaces, not '\t'
+set expandtab
+
+" Allows arrows and h/l to move to next line when at the end of one
+set whichwrap+=<,>,h,l
 
 " ----------------------------------------------------------------------------
 " Visual display settings
 " ----------------------------------------------------------------------------
 colorscheme zenburn              " colorscheme to use
-set scrolloff=3                  " keep some lines above and below the cursor to keep context visible
-set list                         " show non-printing chars
-set showmatch                    " show matching parentheses
-set nu                           " display line numbers
-set wrap                         " wrap lines
-set noshowmode                   " for use with vim-airline, which has its own
-set mouse=a                      " allow mouse usage
-set encoding=utf-8               " default encoding
-:autocmd InsertEnter * set cul   " color the current line in insert mode
-:autocmd InsertLeave * set nocul " remove color when leaving insert mode
+" Keep some lines above and below the cursor to keep context visible
+set scrolloff=3
 
-" Display nonprinting characters
-" <TAB> characters become >...
-" Trailing spaces show up as dots
+" Show non-printing chars
+set list
+
+" Show matching parentheses
+set showmatch
+
+" Display line numbers
+set nu
+
+" Wrap lines
+set wrap
+
+" For use with vim-airline, which has its own
+set noshowmode
+
+" Allow mouse usage.
+" - Mouse-enabled motions: left-click to place the cursor. Type 'y' then
+"   left-click to yank from current cursor to where you next clicked.
+" - Drag the status-line or vertical separator to resize
+" - Double-click to select word; triple-click for line
+set mouse=a
+
+" Color the current line in insert mode
+:autocmd InsertEnter * set cul
+
+" Remove color when leaving insert mode
+:autocmd InsertLeave * set nocul
+
+" ----------------------------------------------------------------------------
+" Display nonprinting characters (tab characters and trailing spaces)
+" ----------------------------------------------------------------------------
+" Differentiating between tabs and spaces is extremely helpful in tricky
+" debugging situations.
+"
+" With these settings <TAB> characters look like >••••.
+"
+" Trailing spaces show up as dots like ∙∙∙∙∙.
+"
+" The autocmds here mean that we only show the trailing spaces when we're
+" outside of insert mode, so that every space typed doesn't show up as
+" trailing.
+"
 " When wrap is off, extends and precedes indicate that there's text offscreen
-" The autocmds here only show the trailing spaces when we're outside of insert
-" mode, so that every space typed doesn't show up as trailing.
-:autocmd InsertEnter * set listchars=tab:>.
-:autocmd InsertLeave * set listchars=tab:>.,trail:∙,nbsp:•,extends:⟩,precedes:⟨
+:autocmd InsertEnter * set listchars=tab:>•
+:autocmd InsertLeave * set listchars=tab:>•,trail:∙,nbsp:•,extends:⟩,precedes:⟨
 
 " ----------------------------------------------------------------------------
 " Format options
 " ----------------------------------------------------------------------------
-set formatoptions=qrn1c   " q: gq also formats comments
-                          " r: insert comment leader after <Enter> in insert mode
-                          " n: recognize numbered lists
-                          " 1: don't break a line after a 1-letter word
-                          " c: autoformat comments
+"  Changes the behavior of various formatting
+"  See :h formatoptions
+set formatoptions=qrn1coj
+" q: gq also formats comments
+" r: insert comment leader after <Enter> in insert mode
+" n: recognize numbered lists
+" 1: don't break a line after a 1-letter word
+" c: autoformat comments
+" o: automatically insert comment leader afer 'o' or 'O' in Normal mode.
+"    Use Ctrl-u to quickly delete it if you didn't want it.
+" j: where it makes sense, remove a comment leader when joining lines
 
 " ----------------------------------------------------------------------------
 " General behavior
 " ----------------------------------------------------------------------------
-set hidden           " open a new buffer without having to save first
-set history=1000     " remember more commands and search history
-set undolevels=1000  " use many levels of undo
-set noswapfile       " disable swap file creation. Keep enabled for huge files
+" Open a new buffer without having to save first
+set hidden
+
+" Disable swap file creation. Keep enabled for huge files (:set swapfile)
+set noswapfile
+
 
 " ----------------------------------------------------------------------------
 " Searching
 " ----------------------------------------------------------------------------
-set ignorecase  " ignore case when searching...
-set smartcase   " ...unless at least one character is uppercase
-set nohlsearch  " don't highlight search items by default
+" Ignore case when searching...
+set ignorecase
+
+" ...unless at least one character is uppercase
+set smartcase
+
+" Don't highlight search items by default
+set nohlsearch
 
 " ----------------------------------------------------------------------------
 " Tab completion settings
 " ----------------------------------------------------------------------------
-set wildmenu            " make tab completion for files/buffers act like bash
-set wildmode=list:full  " show a list when pressing tab; complete first full match
-set wildignore=*.swp,*.bak,*.pyc,*.class  " ignore these when autocompleting
+" Make tab completion for files/buffers act like bash
+set wildmenu
+
+" Show a list when pressing tab; complete first full match
+set wildmode=list:full
+"
+" Ignore these when autocompleting
+set wildignore=*.swp,*.bak,*.pyc,*.class
 
 set inccommand=nosplit  " when using :s/ to search and replace, this will give
                         " a live preview of the proposed changes
@@ -202,6 +260,9 @@ noremap <silent> ,j :wincmd j<cr>
 noremap <silent> ,k :wincmd k<cr>
 noremap <silent> ,l :wincmd l<cr>
 
+" ,q and ,w move to left and right windows respectively. Useful when working
+" with a terminal. ,q will go back to text buffer even in insert mode in
+" a terminal buffer. Can be more ergonomic than ,h and ,l defined above.
 noremap <silent> ,w :wincmd l<cr>
 noremap <silent> ,q :wincmd h<cr>
 
@@ -228,8 +289,8 @@ au BufRead,BufNewFile *.snakefile setfiletype python
 " ============================================================================
 " RELATIVE NUMBERING
 " ============================================================================
-" Relative numbering. Use <Leader>r to turn on relative line numbering --
-" useful for choosing how many lines to delete, for example.
+" ,r to enable relative numbering -- useful for choosing how many lines to
+" delete, for example.
 function! NumberToggle()
   if(&relativenumber == 1)
     set nornu
@@ -272,13 +333,15 @@ nmap <Leader>t3e :vert rightb Tnew<CR>:wincmd l<CR>source activate ../../../env<
 
 
 " When in a terminal, by default Esc does not go back to normal mode and
-" instead you need to use Ctrl-\ Ctrl-n. This remaps to use Esc.
+" instead you need to use Ctrl-\ Ctrl-n. That's pretty awkward; this remaps to
+" use Esc.
 tnoremap <Esc> <C-\><C-n>
 
 " Any time a terminal is entered, go directly into Insert mode. This makes it
 " behave a little more like a typical terminal.
 :au BufEnter,FocusGained,BufWinEnter,WinEnter * if &buftype == 'terminal' | :startinsert | endif
 :au BufLeave,FocusLost,BufWinLeave,WinLeave * if &buftype == 'terminal' | :stopinsert | endif
+" ,gxx to send current line to terminal
 
 " The above autocommand triggers a bug so we need a workaround.
 "
@@ -301,29 +364,31 @@ nmap gxx <Plug>(neoterm-repl-send-line)<CR>
 
 " Use the same mnemonic when working in IPython
 :autocmd FileType python nmap <Leader>k :T run %<CR>
+" ,gx to send current selection (line or visual) to terminal
 
 " Have Neoterm scroll to the end of its buffer after running a command
 let g:neoterm_autoscroll = 1
+" ,k to render the current RMarkdown file to HTML (named after the current file)
+:autocmd FileType rmarkdown nmap <leader>k :T rmarkdown::render("%")<CR>
 
 " Let the user determine what REPL to load
 let g:neoterm_auto_repl_cmd = 0
 
-" Send RMarkdown code chunk.
+" ,cd to send RMarkdown code chunk and move to the next one.
 "
-" When inside a code chunk, <Leader>cd selects the chunk and sends to neoterm.
 " Breaking this down...
 "
-" /```{<CR>                       -> search for chunk delimiter (recall <CR> is Enter)
-" N                               -> find the *previous* match to ```{
-" j                               -> move down one line from the previous match
-" V                               -> enter visual line-select mode
-" /^```\n<CR>                     -> select until the next chunk delimiter by itself on the line (which should be the end)
-" k                               -> go up one line from that match so we don't include that line
-" <Plug>(neoterm-repl-send)<CR>   -> send the selection to the neoterm terminal
-" /```{r<CR>                      -> go to the start of the next chunk
-nmap <Leader>cd /```{<CR>NjV/```\n<CR>k<Plug>(neoterm-repl-send)<CR>/```{r<CR>
-
-" This adds commonly-used YAML front matter to RMarkdown documents
+" /```{<CR>                                 -> search for chunk delimiter (recall <CR> is Enter)
+" N                                         -> find the *previous* match to ```{
+" j                                         -> move down one line from the previous match
+" V                                         -> enter visual line-select mode
+" /^```\n<CR>                               -> select until the next chunk delimiter by itself on the line (which should be the end)
+" k                                         -> go up one line from that match so we don't include that line
+" <Esc>:ToggleTermSendVisualSelection<CR>   -> send the selection to the terminal
+" /```{r<CR>                                -> go to the start of the next chunk
+" ,yr to add commonly-used YAML front matter to RMarkdown documents. Mnemonic is
+" 'YAML for RMarkdown'. It adds this:
+"
 " ---
 " output:
 "   html_document:
@@ -334,8 +399,8 @@ nmap <Leader>cd /```{<CR>NjV/```\n<CR>k<Plug>(neoterm-repl-send)<CR>/```{r<CR>
 " ---
 nmap <Leader>ry i---<CR>output:<CR>  html_document:<CR>  code_folding: hide<CR>toc: true<CR>toc_float: true<CR>toc_depth: 3<CR><BS>---<Esc>0
 
-" Insert a knitr global options chunk.
 nmap <Leader>ko i<CR>```{r}<CR>knitr::opts_chunk$set(warning=FALSE, message=FALSE)<CR>```<CR><Esc>0
+" ,ko to insert a knitr global options chunk. Mnemonic is 'knitr options'
 
 
 " ----------------------------------------------------------------------------
@@ -347,17 +412,6 @@ let g:airline_theme = "powerlineish"
 set laststatus=2
 let g:airline_powerline_fonts = 1
 let g:bufferline_echo = 0
-
-" These might be useful later -- in case you're not using a powerline font
-" let g:airline#extensions#tabline#left_sep = ' '
-" let g:airline#extensions#tabline#left_alt_sep = '|'
-" let g:airline#extensions#tabline#right_sep = ' '
-" let g:airline#extensions#tabline#right_alt_sep = '|'
-" let g:airline_left_sep = ' '
-" let g:airline_left_alt_sep = '|'
-" let g:airline_right_sep = ' '
-" let g:airline_right_alt_sep = '|'
-" let g:airline_theme= 'gruvbox'
 
 " ----------------------------------------------------------------------------
 " vim-pandoc and vim-pandoc-syntax

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -29,6 +29,7 @@ Plug 'snakemake/snakemake', {'rtp': 'misc/vim', 'branch': 'main'} " Snakemake sy
 Plug 'ggandor/leap.nvim'                  " Jump around in a buffer with low mental effort
 Plug 'tpope/vim-surround'
 Plug 'akinsho/toggleterm.nvim', {'tag' : '*'}
+Plug 'phha/zenburn.nvim'
 call plug#end()
 
 " ============================================================================
@@ -40,6 +41,8 @@ call plug#end()
 lua <<EOF
 -- Some Lua packages need to have their setup() function run.
 require('leap').set_default_keymaps()
+require("zenburn").setup()
+
 -- Override the ToggleTerm setting for vertical split terminal
 require('toggleterm').setup{
   size = function(term)
@@ -86,7 +89,6 @@ set whichwrap+=<,>,h,l
 " ----------------------------------------------------------------------------
 " Visual display settings
 " ----------------------------------------------------------------------------
-colorscheme zenburn              " colorscheme to use
 " Keep some lines above and below the cursor to keep context visible
 set scrolloff=3
 

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -237,13 +237,13 @@ autocmd FileType markdown noremap  <leader>d <Esc>:r! date "+\# \%Y-\%m-\%d"<CR>
 " ,- to fill the rest of the line with dashes
 nnoremap <leader>- 80A-<Esc>d80<bar>
 
-" Hard-wrap at 80 columns. Mnemonic is md = 'markdown', a common filetype where
-" this is useful
-nnoremap <leader>md :set tw=80 fo+=t<CR>
+" ,md to hard-wrap at 80 columns and reformat paragraphs as they are written.
+" Mnemonic is md = 'markdown', a common filetype where this is useful
+nnoremap <leader>md :set tw=80 fo+=ta<CR>
 
-" Unset the hard-wrap. Mnemonic is 'not markdown', to indicate the opposite of
-" the ,md above.
-nnoremap <leader>nd :set tw=80 fo-=t<CR>
+" ,nd to unset the hard-wrap. Mnemonic is 'not markdown', to indicate the
+" opposite of the ,md above.
+nnoremap <leader>nd :set tw=80 fo-=ta<CR>
 
 " ,<TAB> for slightly saner behavior with long TSV lines. Leaves the cursor in
 " the command bar so you can type in an appropriate tab stop value. Mnemonic of

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -394,7 +394,8 @@ nmap <leader>cd /```{<CR>NjV/```\n<CR>k<Esc>:ToggleTermSendVisualSelection<CR>/`
 "     toc_float: true
 "     toc_depth: 3
 " ---
-nmap <Leader>ry i---<CR>output:<CR>  html_document:<CR>  code_folding: hide<CR>toc: true<CR>toc_float: true<CR>toc_depth: 3<CR><BS>---<Esc>0
+"
+nmap <leader>yr i---<CR>output:<CR>  html_document:<CR>  code_folding: hide<CR>toc: true<CR>toc_float: true<CR>toc_depth: 3<CR><BS>---<Esc>0
 
 " ,ko to insert a knitr global options chunk. Mnemonic is 'knitr options'
 nmap <leader>ko i<CR>```{r}<CR>knitr::opts_chunk$set(warning=FALSE, message=FALSE)<CR>```<CR><Esc>0

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -291,6 +291,7 @@ nmap <leader>P "+P
 " ----------------------------------------------------------------------------
 "  Window navigation
 " ----------------------------------------------------------------------------
+" ,h ,j ,k and ,l to navigate windows
 noremap <silent> ,h :wincmd h<cr>
 noremap <silent> ,j :wincmd j<cr>
 noremap <silent> ,k :wincmd k<cr>
@@ -301,14 +302,7 @@ noremap <silent> ,l :wincmd l<cr>
 " a terminal buffer. Can be more ergonomic than ,h and ,l defined above.
 noremap <silent> ,w :wincmd l<cr>
 noremap <silent> ,q :wincmd h<cr>
-
-" The above mppings for ,w and ,q to move between windows requires being in
-" Normal mode first. The following commands let you use Alt-w and Alt-q to
-" switch -- even while in Insert mode.
-noremap <M-w> <Esc>:wincmd l<CR>
-inoremap <M-w> <Esc>:wincmd l<CR>
-
-tnoremap <M-q> <C-\><C-n>:wincmd h<CR>
+tnoremap <silent> ,q <C-\><C-n>:wincmd h<cr>
 
 
 " ============================================================================

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -139,9 +139,18 @@ let @l = "I'A',j"
 " Set the working directory to that of the opened file
 autocmd BufEnter * silent! lcd %:p:h
 
+" Insert timestamp. Useful when writing logs
+inoremap <leader>dt <Esc>o<Esc>:r! date "+[\%Y-\%m-\%d \%H:\%M] "<CR>A
+noremap <leader>dt <Esc>o<Esc>:r! date "+[\%Y-\%m-\%d \%H:\%M] "<CR>A
+
 " Insert an ReST-formatted title for today's date
-inoremap <leader>d <Esc>:r! date "+\%Y-\%m-\%d"<CR>A<CR>----------<CR>
-noremap <leader>d <Esc>:r! date "+\%Y-\%m-\%d"<CR>A<CR>----------<CR><Esc>
+autocmd FileType rst inoremap <leader>d <Esc>:r! date "+\%Y-\%m-\%d"<CR>A<CR>----------<CR>
+autocmd FileType rst noremap  <leader>d <Esc>:r! date "+\%Y-\%m-\%d"<CR>A<CR>----------<CR><Esc>
+
+" Same, but markdown header
+autocmd FileType markdown inoremap <leader>d <Esc>:r! date "+\# \%Y-\%m-\%d"<CR>A
+autocmd FileType markdown noremap  <leader>d <Esc>:r! date "+\# \%Y-\%m-\%d"<CR>A
+
 
 " Fill the rest of the line with dashes
 nnoremap <leader>- 80A-<Esc>d80<bar>

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -6,7 +6,7 @@ call plug#begin()
 
 Plug 'vim-scripts/vis'                    " Operations in visual block mode respect selection
 Plug 'preservim/nerdcommenter'            " Comment large blocks of text
-Plug 'preservim/nerdtree'                 " File browser for vim <Leader>n
+Plug 'preservim/nerdtree'                 " File browser for vim <leader>n
 Plug 'vim-airline/vim-airline'            " Nice statusline. Install powerline fonts for full effect.
 Plug 'vim-airline/vim-airline-themes'     " Themes for the statusline
 Plug 'roxma/vim-tmux-clipboard'           " Copy yanked text from vim into tmux's clipboard and vice versa.
@@ -176,8 +176,8 @@ set inccommand=nosplit  " when using :s/ to search and replace, this will give
 " re-map mapleader from \ to ,
 let mapleader=","
 
-" Toggle search highlight
-noremap <Leader>H :set hlsearch!<CR>
+" ,H to toggle search highlight
+noremap <leader>H :set hlsearch!<CR>
 
 " Helper for pep8: cleans up trailing whitespace
 nnoremap <leader>W :%s/\s\+$//<cr>:let @/=''<CR>
@@ -233,15 +233,15 @@ nnoremap <leader><tab> :set nowrap tabstop=
 " ,l       : list buffers
 " ,b ,f ,g : go back/forward/last-used
 " ,1 ,2 ,3 : go to buffer 1/2/3 etc
-nnoremap <Leader>1 :1b<CR>
-nnoremap <Leader>2 :2b<CR>
-nnoremap <Leader>3 :3b<CR>
-nnoremap <Leader>4 :4b<CR>
-nnoremap <Leader>5 :5b<CR>
-nnoremap <Leader>6 :6b<CR>
-nnoremap <Leader>7 :7b<CR>
-nnoremap <Leader>8 :8b<CR>
-nnoremap <Leader>9 :9b<CR>
+nnoremap <leader>1 :1b<CR>
+nnoremap <leader>2 :2b<CR>
+nnoremap <leader>3 :3b<CR>
+nnoremap <leader>4 :4b<CR>
+nnoremap <leader>5 :5b<CR>
+nnoremap <leader>6 :6b<CR>
+nnoremap <leader>7 :7b<CR>
+nnoremap <leader>8 :8b<CR>
+nnoremap <leader>9 :9b<CR>
 
 " ----------------------------------------------------------------------------
 " Copy/paste
@@ -399,8 +399,8 @@ let g:neoterm_auto_repl_cmd = 0
 " ---
 nmap <Leader>ry i---<CR>output:<CR>  html_document:<CR>  code_folding: hide<CR>toc: true<CR>toc_float: true<CR>toc_depth: 3<CR><BS>---<Esc>0
 
-nmap <Leader>ko i<CR>```{r}<CR>knitr::opts_chunk$set(warning=FALSE, message=FALSE)<CR>```<CR><Esc>0
 " ,ko to insert a knitr global options chunk. Mnemonic is 'knitr options'
+nmap <leader>ko i<CR>```{r}<CR>knitr::opts_chunk$set(warning=FALSE, message=FALSE)<CR>```<CR><Esc>0
 
 
 " ----------------------------------------------------------------------------

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -202,6 +202,11 @@ Plug 'tpope/vim-surround'
 "
 Plug 'akinsho/toggleterm.nvim', {'tag' : '*'}
 
+" vim-colorschemes
+" ----------------
+" Lots of colorschemes, including 'zenburn' which is configured below
+Plug 'flazz/vim-colorschemes'
+
 call plug#end()
 
 " ============================================================================

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -341,14 +341,6 @@ nnoremap <leader>n :NERDTreeToggle<cr>
 " ----------------------------------------------------------------------------
 " ToggleTerm
 " ----------------------------------------------------------------------------
-
-" In many cases we have a conda environment nearby named 'env', here are some
-" easy ways to open a terminal and activate it.
-nmap <Leader>te :vert rightb Tnew<CR>:wincmd l<CR>source activate ./env<CR>
-nmap <Leader>t1e :vert rightb Tnew<CR>:wincmd l<CR>source activate ../env<CR>
-nmap <Leader>t2e :vert rightb Tnew<CR>:wincmd l<CR>source activate ../../env<CR>
-nmap <Leader>t3e :vert rightb Tnew<CR>:wincmd l<CR>source activate ../../../env<CR>
-
 " ,t to open a terminal to the right (ToggleTerm)
 nmap <leader>t :ToggleTerm direction=vertical<CR>
 

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -47,3 +47,7 @@ bind -n S-Right next-window
 bind c new-window -c "#{pane_current_path}"
 bind '"' split-window -c "#{pane_current_path}"
 bind % split-window -h -c "#{pane_current_path}"
+
+# Optionally set colors of the status bar at the bottom, which is bright green
+# by default.
+# set -g status-style bg=#586e75,fg=#fdf6e3

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,23 @@
 Changelog
 =========
 
+2022-09-14
+----------
+
+- conda setup now sets the recommended `strict channel priority <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority>`_
+- made some fixes to correctly run on recent Mac OS versions
+
+
+2022-07-22
+----------
+
+- updated git repo for nerdtree and nerdcommenter plugins in ``init.vim`` (thanks @njohnso6)
+
+2022-07-09
+----------
+
+- added new ``prsetup`` function for working on contributed pull requests
+
 2022-05-27
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,22 @@
 Changelog
 =========
 
+2022-12-27
+----------
+Lots of updates to the neovim config, ``.config/nvim/init.vim``:
+
+- The neoterm plugin is no longer actively developed; switched to using
+  ToggleTerm and updated all shortcuts and commands
+- Now ``,q`` from a terminal doesn't need <Esc> first, making switching back to
+  the text buffer much nicer
+- Major improvements in the comments in init.vim to make it easier to learn
+  what does what, and to improve discoverability of features. This includes
+  a brief description of oft-used commands provided by plugins as well as what
+  to search the help for in order to learn more.
+- Using an updated zenburn color scheme
+- Added the "leap" plugin.
+- change ``,ry`` to ``,yr`` for better mnemonic of "YAML for R"
+
 2022-09-14
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,7 +16,6 @@ Lots of updates to the neovim config, ``.config/nvim/init.vim``:
   what does what, and to improve discoverability of features. This includes
   a brief description of oft-used commands provided by plugins as well as what
   to search the help for in order to learn more.
-- Using an updated zenburn color scheme
 - Added the "leap" plugin.
 - change ``,ry`` to ``,yr`` for better mnemonic of "YAML for R"
 

--- a/setup.sh
+++ b/setup.sh
@@ -104,6 +104,12 @@ function showHelp() {
         "neovim is a drop-in replacement for vim, with additional features" \
         "Homepage: https://neovim.io/"
 
+    cmd "--compile-neovim" \
+        "If installing Neovim doesn't work or you want a more recent version," \
+        "use this command. You will need the prequisites " \
+        " (https://github.com/neovim/neovim/wiki/Building-Neovim#build-prerequisites) " \
+        "installed."
+
     cmd "--set-up-vim-plugins" \
         "vim-plug needs to be installed separately," \
         "and then all vim plugins can be simply be installed" \
@@ -480,6 +486,28 @@ elif [ $task == "--install-neovim" ]; then
         printf "${YELLOW}- installed neovim to $HOME/opt/neovim${UNSET}\n"
         printf "${YELLOW}- created symlink $HOME/opt/bin/nvim${UNSET}\n"
         check_opt_bin_in_path
+
+elif [ $task == "--compile-neovim" ]; then
+    NVIM_VERSION=stable
+    ok "Clones the stable branch of the neovim repo, compiles it, and installs it into $HOME/opt/bin/nvim"
+    if [ -e "$HOME/opt/neovim" ];
+    then
+        ok "Warning, need to delete $HOME/opt/neovim, is that ok?"
+        rm -rv "$HOME/opt/neovim"
+    fi
+    download https://github.com/neovim/neovim/archive/refs/tags/stable.zip neovim-stable.zip
+    unzip neovim-stable.zip
+    (
+        cd neovim-stable
+        make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$HOME/opt/neovim"
+        make install
+        mkdir -p "$HOME/opt/bin"
+        ln -sf "$HOME/opt/neovim/bin/nvim" "$HOME/opt/bin/nvim"
+    )
+    rm -rf neovim-stable.zip neovim-stable
+    printf "${YELLOW}- installed neovim to $HOME/opt/neovim${UNSET}\n"
+    printf "${YELLOW}- created symlink $HOME/opt/bin/nvim${UNSET}\n"
+    check_opt_bin_in_path
 
 
 elif [ $task == "--set-up-vim-plugins" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,19 @@ if [ -e ~/.bashrc ]; then
     source ~/.bashrc
 fi
 
+# Change tool versions here
+VISIDATA_VERSION=2.8
+HUB_VERSION=2.14.2
+NVIM_VERSION=0.7.0
+RG_VERSION=13.0.0
+BAT_VERSION=0.19.0
+JQ_VERSION=1.6
+ICDIFF_VERSION=2.0.4
+BFG_VERSION=1.14.0
+FD_VERSION=8.5.3
+BLACK_VERSION=22.6.0
+PYP_VERSION=1.1.0
+
 function showHelp() {
 
     function header() {
@@ -469,7 +482,6 @@ elif [ $task == "--conda-env" ]; then
 
 
 elif [ $task == "--install-neovim" ]; then
-    NVIM_VERSION=0.7.0
     ok "Downloads neovim tarball from https://github.com/neovim/neovim, install into $HOME/opt/bin/neovim"
     if [[ $OSTYPE == darwin* ]]; then
         download https://github.com/neovim/neovim/releases/download/v${NVIM_VERSION}/nvim-macos.tar.gz nvim-macos.tar.gz
@@ -564,7 +576,6 @@ elif [ $task == "--install-fzf" ]; then
 elif [ $task == "--install-ripgrep" ]; then
     ok "Installs ripgrep to $HOME/opt/bin"
     mkdir -p /tmp/rg
-    RG_VERSION=13.0.0
 
     if [[ $OSTYPE == darwin* ]]; then
         URL=https://github.com/BurntSushi/ripgrep/releases/download/$RG_VERSION/ripgrep-$RG_VERSION-x86_64-apple-darwin.tar.gz
@@ -582,21 +593,20 @@ elif [ $task == "--install-ripgrep" ]; then
 
 elif [ $task == "--install-fd" ]; then
     ok "Install fd (https://github.com/sharkdp/fd) into a new conda env and symlink to ~/opt/bin/fd"
-    install_env_and_symlink fd fd-find fd
+    install_env_and_symlink fd fd-find="${FD_VERSION}" fd
     printf "${YELLOW}Installed to ~/opt/bin/fd${UNSET}\n"
     check_opt_bin_in_path
 
 
 elif [ $task == "--install-vd" ]; then
     ok "Install visidata (https://visidata.org/) into a new conda env and symlink to ~/opt/bin/vd"
-    install_env_and_symlink visidata visidata vd
+    install_env_and_symlink visidata visidata="${VISIDATA_VERSION}" vd
     printf "${YELLOW}Installed to ~/opt/bin/vd${UNSET}\n"
     check_opt_bin_in_path
 
 
 elif [ $task == "--install-hub" ]; then
     ok "Installs hub to $HOME/opt (https://github.com/github/hub)"
-    HUB_VERSION=2.14.2
     if [[ $OSTYPE == darwin* ]]; then
         (
             download https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-darwin-amd64-${HUB_VERSION}.tgz /tmp/hub.tar.gz
@@ -620,7 +630,7 @@ elif [ $task == "--install-hub" ]; then
 
 elif [ $task == "--install-black" ]; then
     ok "Install black (https://black.readthedocs.io) into a new conda env and symlink to ~/opt/bin/black"
-    install_env_and_symlink black black black
+    install_env_and_symlink black black="${BLACK_VERSION}" black
     printf "${YELLOW}Installed to ~/opt/bin/black${UNSET}\n"
     check_opt_bin_in_path
 
@@ -643,7 +653,6 @@ elif [ $task == "--install-radian" ]; then
 
 elif [ $task == "--install-bat" ]; then
     ok "Installs bat (https://github.com/sharkdp/bat). Extracts the binary to ~/opt/bin"
-    BAT_VERSION=0.19.0
     BAT_TARBALL="/tmp/bat-${BAT_VERSION}.tar.gz"
     if [[ $OSTYPE == darwin* ]]; then
         download \
@@ -714,7 +723,6 @@ elif [ $task == "--install-alacritty" ]; then
 
 
 elif [ $task == "--install-jq" ]; then
-    JQ_VERSION=1.6
     ok "Installs jq to $HOME/opt/bin"
     if [[ $OSTYPE == darwin* ]]; then
         download https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-osx-amd64 $HOME/opt/bin/jq
@@ -728,7 +736,6 @@ elif [ $task == "--install-jq" ]; then
 
 elif [ $task == "--install-icdiff" ]; then
     ok "Install icdiff (https://github.com/jeffkaufman/icdiff) into ~/opt/bin"
-    ICDIFF_VERSION=2.0.4
     download https://raw.githubusercontent.com/jeffkaufman/icdiff/release-${ICDIFF_VERSION}/icdiff ~/opt/bin/icdiff
     chmod +x ~/opt/bin/icdiff
     printf "${YELLOW}Installed to ~/opt/bin/icdiff${UNSET}\n"
@@ -740,7 +747,7 @@ elif [ $task == "--install-pyp" ]; then
     can_make_conda_env "pyp"
     conda create -y -n pyp python
     conda activate pyp
-    pip install pypyp
+    pip install pypyp==${PYP_VERSION}
     ln -sf $(which pyp) $HOME/opt/bin/pyp
     conda deactivate
     printf "${YELLOW}Installed to ~/opt/bin/pyp${UNSET}\n"
@@ -761,7 +768,6 @@ elif [ $task == "--install-zoxide" ]; then
 
 elif [ $task == "--install-bfg" ]; then
     ok "Install BFG (https://rtyley.github.io/bfg-repo-cleaner/) git repo cleaner to ~/opt/bin?"
-    BFG_VERSION=1.14.0
     BFG_WRAPPER=~/opt/bin/bfg
     download https://repo1.maven.org/maven2/com/madgag/bfg/${BFG_VERSION}/bfg-${BFG_VERSION}.jar ~/opt/bin/bfg-${BFG_VERSION}.jar
 

--- a/setup.sh
+++ b/setup.sh
@@ -416,7 +416,7 @@ elif [ $task == "--install-miniconda" ]; then
     ok "Installs Miniconda
        - installs to $MINICONDA_DIR
        - runs 'conda init bash'
-       - prints notes and recommendations for next steps'
+       - prints notes and recommendations for next steps
     "
     if [[ $OSTYPE == darwin* ]]; then
         download https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh miniconda.sh
@@ -437,6 +437,11 @@ elif [ $task == "--install-miniconda" ]; then
     printf "${YELLOW}Miniconda installed to $MINICONDA_DIR.${UNSET}\n"
     printf "${YELLOW}   and then ran \"$MINICONDA_DIR/bin/conda init bash\", \n${UNSET}"
     printf "${YELLOW}   which added lines to your .bashrc. You should check out those lines.${UNSET}\n\n"
+
+    if [[ $OSTYPE == darwin* ]]; then
+        printf "${YELLOW}Looks like you're on a Mac: in this case, look in ~/.bash_profile for the\n"
+        printf "lines added by conda init bash. Move them from ~/.bash_profile to ~/.bashrc.${UNSET}\n\n"
+    fi
 
 elif [ $task == "--set-up-bioconda" ]; then
     ok "Sets up Bioconda by adding the dependent channels in the correct order"

--- a/setup.sh
+++ b/setup.sh
@@ -448,6 +448,7 @@ elif [ $task == "--set-up-bioconda" ]; then
     conda config --add channels defaults
     conda config --add channels bioconda
     conda config --add channels conda-forge
+    conda config --set channel_priority strict
     printf "${YELLOW}Channels configured, see ~/.condarc${UNSET}\n"
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -364,6 +364,9 @@ check_opt_bin_in_path () {
 # All of these may be the same, but there is flexibility to handle cases where
 # they are not
 install_env_and_symlink () {
+
+    # sometimes conda can complain about env vars being unset
+    set +u
     ENVNAME=$1
     CONDAPKG=$2
     EXECUTABLE=$3
@@ -373,6 +376,7 @@ install_env_and_symlink () {
     ln -sf "$CONDA_LOCATION/envs/$ENVNAME/bin/$EXECUTABLE" $HOME/opt/bin/$EXECUTABLE
     printf "${YELLOW}Installed $HOME/opt/bin/$EXECUTABLE${UNSET}\n"
     check_opt_bin_in_path
+    set -u
 }
 
 # TASKS ----------------------------------------------------------------------
@@ -744,6 +748,7 @@ elif [ $task == "--install-icdiff" ]; then
 
 elif [ $task == "--install-pyp" ]; then
     ok "Install pyp (https://github.com/hauntsaninja/pyp) into ~/opt/bin"
+    set +u
     can_make_conda_env "pyp"
     conda create -y -n pyp python
     conda activate pyp
@@ -752,6 +757,7 @@ elif [ $task == "--install-pyp" ]; then
     conda deactivate
     printf "${YELLOW}Installed to ~/opt/bin/pyp${UNSET}\n"
     check_opt_bin_in_path
+    set -u
 
 
 elif [ $task == "--install-zoxide" ]; then


### PR DESCRIPTION
This PR is the result of a review of the existing nvim config, evaluating the existing state of the art in nvim setup, and careful documentation of the init.vim file to encourage learning and discovery of features added by that config.

### `.config/nvim/init.vim`

- each plugin is better documented, including information about what it does as well as what commands it makes available.
- when a mapping is configured, the mapping itself comes first in the comment to make things more discoverable
- use ToggleTerm instead of neoterm (since the latter is no longer actively developed), and improves the quality of life a bit when using a terminal from nvim, specifically, supporting `,q` to go back to the text buffer without having to use `<Esc>` first. From the user perspective, there should be no differences as all the existing shortcuts have been ported to ToggleTerm
- now including the "leap" plugin
- now including highlight on yank
- config items that are defaults have been removed

I considered fully refactoring into Lua (and in fact have a working Lua version of this) but considered it additional overhead for others to learn. This version keeps the Lua to a minimum.

I also considered doing the full LSP setup (following https://github.com/nvim-lua/kickstart.nvim) but likewise considered it too much overhead. In particular, I did not consider the requirement to install NPM and the additional config to be worth the gain.

**Now that everything is documented in the init.vim comments, users should read through those comments and decide what they want to keep or port over to their own init.vim.**

## `setup.sh`

- added `--compile-neovim`, in cases where installing the binary does not work (e.g. on an older Linux OS with older GLIBC). However, note that nvim versions >=0.8 seem to have broken syntax for Lua-embedded code in the `init.vim`, which can make it annoying to read through the file with strange colors. So for now, it's probably better to use the `--install-neovim` which is currently pinned to installing 0.7.0 (which still works with older GLIBC).
