### PR TITLE
conda improvements

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -36,3 +36,4 @@ alias git-clean-branches="git branch --merged master | grep -v \"\* master\" | x
 alias gsv="vim -c ':Git' -c ':bunload 1'"
 alias glv="vim -c ':GV'"
 alias e="conda activate ./env"
+alias s="start_agent"

--- a/.bashrc
+++ b/.bashrc
@@ -32,3 +32,13 @@ fi
 if [[ $OSTYPE == darwin* ]]; then
     test -f ~/.git-completion.bash && source ~/.git-completion.bash
 fi
+
+# New bash shells spawned by tmux will silently break conda environments by
+# placing the system path in front of the conda env path -- even though the
+# prompt still indicates an active environment. This can be quite confusing.
+#
+# So if we're starting a bash shell under tmux, deactivate all environments.
+#
+# The `ca` and `conda_deactivate_all` functions used here are defined in the
+# .functions file, which in turn was sourced at the beginning of this file.
+[[ -z $TMUX ]] || ca; conda_deactivate_all

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -255,7 +255,7 @@ endif
 syntax on
 
 " Set colorscheme here
-colorscheme zenburn
+:silent! colorscheme zenburn
 
 " Enable detection, plugin , and indent for filetype
 filetype plugin indent on

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -215,6 +215,7 @@ call plug#end()
 " The 'lua' command runs a line of Lua.
 " The 'lua <<EOF .... EOF' syntax allows multiple Lua lines.
 " Here, we run all of the Lua in one block.
+if has('nvim')
 
 lua <<EOF
 
@@ -245,6 +246,7 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   pattern = '*',
 })
 EOF
+endif
 
 " ============================================================================
 " SETTINGS
@@ -366,9 +368,11 @@ set smartcase
 " Don't highlight search items by default
 set nohlsearch
 
-" When using :s/ to search and replace, this will give a live preview of the
-" proposed changes
-set inccommand=nosplit
+if has('nvim')
+    " When using :s/ to search and replace, this will give a live preview of the
+    " proposed changes
+    set inccommand=nosplit
+endif
 
 " Make tab completion for files/buffers act like bash
 set wildmenu

--- a/.functions
+++ b/.functions
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 
-# start the ssh-agent
-SSH_ENV=$HOME/.ssh/environment
+# Start the ssh-agent and add keys to the agent.
+# Detects if on Mac; if so detects the macOS version and provides the
+# appropriate pargs to add keys to the keychain
 function start_agent {
     echo "Initializing new SSH agent..."
-    /usr/bin/ssh-agent | sed 's/^echo/#echo/' > "${SSH_ENV}"
-    echo succeeded
-    chmod 600 "${SSH_ENV}"
-    . "${SSH_ENV}" > /dev/null
-    /usr/bin/ssh-add
+    eval "$(ssh-agent)"
+
+    additional_arg=""
+    if [[ $OSTYPE == darwin* ]]; then
+        if [[ $(sw_vers -productVersion | cut -f1 -d '.') -lt 12 ]]; then
+            additional_arg="-K"
+        else
+            additional_arg="--apple-use-keychain"
+        fi
+    fi
+    ssh-add "$additional_arg"
 }
 
 # `tre` is a shorthand for `tree` with hidden files and color enabled, ignoring

--- a/.functions
+++ b/.functions
@@ -68,3 +68,22 @@ function prsetup {
     echo "Now make changes, and run:"
     echo "  git push $contributor HEAD:$contributor_branch"
 }
+
+function ca() {
+    # This function allows you only activate the base env when you're ready to
+    # (and don't activate it on EVERY new shell).
+    #
+    # You can also provide an env name or path to activate it.
+    eval "$(conda shell.bash hook 2> /dev/null)"
+    conda activate "$@"
+}
+
+
+function conda_deactivate_all() {
+    # Keep deactivating until we no longer have a CONDA_PREFIX env var (which
+    # might be a few times, if we had activated the base env and then another
+    # env)
+    while [ -n "$CONDA_PREFIX" ]; do
+        conda deactivate;
+    done
+}

--- a/.path
+++ b/.path
@@ -1,2 +1,3 @@
 export PATH=$PATH:$HOME/opt/bin
 export PATH=$PATH:$HOME/miniconda3/bin
+export PATH=$PATH:$HOME/mambaforge/bin

--- a/.path
+++ b/.path
@@ -1,3 +1,2 @@
 export PATH=$PATH:$HOME/opt/bin
-export PATH=$PATH:$HOME/miniconda3/bin
-export PATH=$PATH:$HOME/mambaforge/bin
+export PATH=$PATH:$HOME/mambaforge/condabin

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,10 @@ RUN ./setup.sh --install-hub
 RUN ./setup.sh --install-icdiff
 RUN ./setup.sh --install-jq
 RUN ./setup.sh --install-pyp
-RUN ./setup.sh --install-radian
+
+# Not working on --platform=linux/amd64
+# RUN ./setup.sh --install-radian
+
 RUN ./setup.sh --install-ripgrep
 RUN ./setup.sh --install-vd
 RUN ./setup.sh --install-tmux

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,10 @@ RUN ./setup.sh --dotfiles
 # This one has been prone to problems, so run it first to save CI time
 RUN ./setup.sh --install-alacritty
 
-RUN ./setup.sh --install-miniconda
+RUN ./setup.sh --install-conda
 RUN ./setup.sh --set-up-bioconda
 RUN ./setup.sh --install-neovim
 RUN ./setup.sh --set-up-vim-plugins
-
-# Don't know why yet, but the alias isn't sticking. But this installs plugins
-# without interaction
-RUN source ~/.bashrc; nvim +PlugInstall +qall
 
 # Various installations using ./setup.sh
 RUN ./setup.sh --install-autojump
@@ -58,6 +54,7 @@ RUN ./setup.sh --install-pyp
 RUN ./setup.sh --install-radian
 RUN ./setup.sh --install-ripgrep
 RUN ./setup.sh --install-vd
+RUN ./setup.sh --install-tmux
 
 # Additional for this container: asciinema for screen casts
 RUN source ~/.bashrc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 SHELL ["/bin/bash", "-c"]
 
-RUN apt-get update && apt-get install -y git wget curl sudo rsync locales
+RUN apt-get update && apt-get install -y git wget curl sudo rsync locales vim
 
 # Locale is set in .bash_profile; needs to be created
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,6 @@ ENV DOTFILES_FORCE=true
 RUN ./setup.sh --apt-install-minimal
 RUN ./setup.sh --dotfiles
 
-# This one has been prone to problems, so run it first to save CI time
-RUN ./setup.sh --install-alacritty
-
 RUN ./setup.sh --install-conda
 RUN ./setup.sh --set-up-bioconda
 RUN ./setup.sh --install-neovim

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,9 @@ RUN ./setup.sh --install-conda
 RUN ./setup.sh --set-up-bioconda
 RUN ./setup.sh --install-neovim
 
+RUN MANUAL_PLUG_INSTALL=1 ./setup.sh --set-up-vim-plugins
 RUN source ~/.bashrc; nvim +PlugInstall +qall
 RUN source ~/.bashrc; $(which vim) +PlugInstall +qall
-
-# Has issues with not being a TTY when running in Docker
-# RUN ./setup.sh --set-up-vim-plugins
 
 # Various installations using ./setup.sh
 RUN ./setup.sh --install-autojump

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,12 @@ RUN ./setup.sh --dotfiles
 RUN ./setup.sh --install-conda
 RUN ./setup.sh --set-up-bioconda
 RUN ./setup.sh --install-neovim
-RUN ./setup.sh --set-up-vim-plugins
+
+RUN source ~/.bashrc; nvim +PlugInstall +qall
+RUN source ~/.bashrc; $(which vim) +PlugInstall +qall
+
+# Has issues with not being a TTY when running in Docker
+# RUN ./setup.sh --set-up-vim-plugins
 
 # Various installations using ./setup.sh
 RUN ./setup.sh --install-autojump

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,27 @@
 Changelog
 =========
 
+2023-07-06
+----------
+
+Updates to support new MacOS and arm64 architecture, and general improvements:
+
+- add ``ca``, ``conda_deactivate_all``, and automatic deactivation within tmux,
+  as well as new documentation to describe the rationale and how to use
+- ``--install-miniconda`` is now ``--install-conda``, and uses Mambaforge
+  instead of Miniconda3. This sets the conda-forge channel and includes mamba.
+  This also now supports all architectures supported by Mambaforge
+- various ``--install-pkgname`` commands use mamba to install rather than conda
+- ``--set-up-vim-plugins`` now runs ``:PlugInstall`` automatically, and does so for both vim and nvim
+- nvim config now protects nvim-only configuration so that you don't get errors opening vim
+- new command for post-installation stuff for mac (``--mac-stuff``)
+- added recommended order of operations to the top of the help
+- add alias for ``start_agent``
+- new ``--install-tmux`` useful for Mac
+- rm installation options for meld as well as the ``--graphical-diffs`` command
+- improved ``start_agent`` function that works well on Mac
+- add docs for mac ssh
+
 2022-12-27
 ----------
 Lots of updates to the neovim config, ``.config/nvim/init.vim``:

--- a/docs/conda.rst
+++ b/docs/conda.rst
@@ -1,0 +1,58 @@
+conda
+=====
+
+Installing conda
+----------------
+
+To install conda, we use `Mambaforge
+<https://github.com/conda-forge/miniforge>`_. This installation sets conda-forge
+as the default (and only) channel, and it includes ``mamba``, a drop-in
+replacement for conda that is faster and more feature-complete.
+
+conda activate, and tmux
+------------------------
+Typically, after installing conda, you run ``conda init bash``. This adds lines
+to your ``.bashrc`` file (if on Linux) or your ``.bash_profile`` file (if on
+Mac). Thereafter, every new bash session will run that code, which involves
+importing some Python libraries and running conda itself. The conda Python
+module loads other modules, and those modules load still others, so that many
+files are touched.
+
+This is totally fine when on a personal machine, since it's unlikely that you'll
+be starting so many bash sessions that you notice any sort of slowdown from the
+I/O load of many files. But this kind of I/O slowdown could easily happen in
+a high-performance computing environment (like NIH's Biowulf) when many jobs are
+kicked off simultaneously.
+
+At the same time, using conda within tmux can get frustrating (on a personal
+computer or HPC system). You may find that on tmux, when you create a new pane
+or window, your prompt still indicates that you're in a conda environment, but
+running ``which python`` returns the *system* Python. It turns out that this is
+because tmux prepends the system path to the PATH when creating a new pane or
+window. The solution is to run ``conda deactivate`` a bunch of times, until the
+prompt no longer has the ``(env_name)`` indicator in it, and *then* activate the
+environment you want.
+
+The solution
+------------
+These dotfiles provide a function, ``ca`` (short for "conda activate"). It's
+defined in the ``~/.functions`` file which in turn is sourced in ``~/.bashrc``.
+This function runs ``eval "$(conda shell.bash hook)"``, which is a way of
+running the same commands that ``conda init bash`` would add to your
+``~/.bashrc``. But it runs it on demand, not every shell.
+
+The ``~/.bashrc`` also has a ``conda_deactivate_all`` function, which keeps
+running ``conda deactivate`` until there's no activated environment.
+
+Last, theres a line in ``~/.bashrc`` that runs ``conda_deactivate_all`` if we're
+in a tmux session.
+
+**Activate the base envirnoment** with ``ca``.
+
+**Activate an environment** with ``ca envname`` or ``ca ./env``
+
+Start tmux. You'll notice that the environment indicators in the prompt
+disappear. That's because ``conda_deactivate_all`` is run on every new bash
+shell started under tmux, to avoid that annoying path munging that breaks conda
+envs. **You will need to activate the environment again** in tmux, and in any
+subsequent tmux window or pane that you create. 

--- a/docs/conda.rst
+++ b/docs/conda.rst
@@ -5,26 +5,28 @@ Installing conda
 ----------------
 
 To install conda, we use `Mambaforge
-<https://github.com/conda-forge/miniforge>`_. This installation sets conda-forge
-as the default (and only) channel, and it includes ``mamba``, a drop-in
-replacement for conda that is faster and more feature-complete.
+<https://github.com/conda-forge/miniforge>`_. Mambaforge is a way of installing
+conda that sets conda-forge as the default (and only) channel, and it includes
+``mamba``, a drop-in replacement for conda that is faster and more
+feature-complete.
 
 conda activate, and tmux
 ------------------------
-Typically, after installing conda, you run ``conda init bash``. This adds lines
+After installing conda, you would typically run ``conda init bash``. This adds lines
 to your ``.bashrc`` file (if on Linux) or your ``.bash_profile`` file (if on
 Mac). Thereafter, every new bash session will run that code, which involves
 importing some Python libraries and running conda itself. The conda Python
 module loads other modules, and those modules load still others, so that many
 files are touched.
 
-This is totally fine when on a personal machine, since it's unlikely that you'll
-be starting so many bash sessions that you notice any sort of slowdown from the
-I/O load of many files. But this kind of I/O slowdown could easily happen in
-a high-performance computing environment (like NIH's Biowulf) when many jobs are
-kicked off simultaneously.
+This is totally fine when on a personal machine, since it's unlikely that
+you'll be starting so many bash sessions that you notice any sort of slowdown
+from the I/O load of many files. But this kind of I/O slowdown could easily
+happen in a high-performance computing environment (like NIH's Biowulf) when
+many jobs are kicked off simultaneously. So we actually want to avoid this on
+HPC environments.
 
-At the same time, using conda within tmux can get frustrating (on a personal
+In addition, using conda within tmux can get frustrating (on either a personal
 computer or HPC system). You may find that on tmux, when you create a new pane
 or window, your prompt still indicates that you're in a conda environment, but
 running ``which python`` returns the *system* Python. It turns out that this is
@@ -35,6 +37,18 @@ environment you want.
 
 The solution
 ------------
+
+.. note::
+
+    Use ``ca`` (short for "conda activate") to activate an environment
+    at the time you want to use it.
+
+    ``ca`` by itself to activate the base environment
+
+    ``ca <envname>`` to activate a specific environment
+
+    Every new tmux pane starts with everything deactivated.
+
 These dotfiles provide a function, ``ca`` (short for "conda activate"). It's
 defined in the ``~/.functions`` file which in turn is sourced in ``~/.bashrc``.
 This function runs ``eval "$(conda shell.bash hook)"``, which is a way of
@@ -42,17 +56,8 @@ running the same commands that ``conda init bash`` would add to your
 ``~/.bashrc``. But it runs it on demand, not every shell.
 
 The ``~/.bashrc`` also has a ``conda_deactivate_all`` function, which keeps
-running ``conda deactivate`` until there's no activated environment.
+running ``conda deactivate`` until there's no activated environment (this idea
+is from `this SO answer <https://stackoverflow.com/a/76304995>`_).
 
 Last, theres a line in ``~/.bashrc`` that runs ``conda_deactivate_all`` if we're
-in a tmux session.
-
-**Activate the base envirnoment** with ``ca``.
-
-**Activate an environment** with ``ca envname`` or ``ca ./env``
-
-Start tmux. You'll notice that the environment indicators in the prompt
-disappear. That's because ``conda_deactivate_all`` is run on every new bash
-shell started under tmux, to avoid that annoying path munging that breaks conda
-envs. **You will need to activate the environment again** in tmux, and in any
-subsequent tmux window or pane that you create. 
+in a tmux session, so it will run on each new tmux pane.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Ready? :ref:`starthere`!
     bash
     vim
     tmux
+    conda
     post
     why
     changelog

--- a/docs/post.rst
+++ b/docs/post.rst
@@ -6,7 +6,7 @@ some things that have to be manually done. This page documents those additional
 tasks.
 
 Mac
-===
+---
 
 - To turn off the iTerm2 audio bell (that "donk!" noise you get after hitting
   TAB): under preferences, go to Profiles, then the Terminal tab. Make sure
@@ -31,9 +31,12 @@ and then as `documented at support.apple.com
   Strip".
 
 SSH config
-==========
+----------
 
-- Create your ssh keys, and add them to the various systems.
+Create your ssh keys, and add them to the various systems. 
+
+See https://nichd-bspc.github.io/training/ssh.html for more details and for
+more specific commands.
 
 .. code-block:: bash
 
@@ -48,7 +51,7 @@ SSH config
     cat ~/.ssh/id_rsa.pub
 
 Git config
-==========
+----------
 
 .. code-block:: bash
 

--- a/docs/post.rst
+++ b/docs/post.rst
@@ -30,10 +30,16 @@ and then as `documented at support.apple.com
   Preferences > Keyboard, then change "Touch Bar shows" to "Expanded Control
   Strip".
 
+- In iTerm preferences:
+  - click the "General" icon, and check "Applications in terminal may access
+    clipboard"
+  - click the "Profiles" icon, and in the "Text" "Use built-in
+    Powerline glyphs"
+
 SSH config
 ----------
 
-Create your ssh keys, and add them to the various systems. 
+Create your ssh keys, and add them to the various systems.
 
 See https://nichd-bspc.github.io/training/ssh.html for more details and for
 more specific commands.

--- a/docs/post.rst
+++ b/docs/post.rst
@@ -56,6 +56,19 @@ more specific commands.
 
     cat ~/.ssh/id_rsa.pub
 
+On Mac, add this to your ``~/.ssh/config`` file (creating it if it doesn't
+exist). Then, by using the ``s`` alias, your SSH key will be added to the
+session using your login to MacOS as the authentication, without needing to
+type in your passphrase
+
+.. code-block::
+
+    # this goes in ~/.ssh/config
+    Host *
+      UseKeychain yes
+      AddKeysToAgent yes
+      IdentityFile ~/.ssh/id_ed25519
+
 Git config
 ----------
 

--- a/docs/post.rst
+++ b/docs/post.rst
@@ -31,8 +31,10 @@ and then as `documented at support.apple.com
   Strip".
 
 - In iTerm preferences:
+
   - click the "General" icon, and check "Applications in terminal may access
     clipboard"
+
   - click the "Profiles" icon, and in the "Text" "Use built-in
     Powerline glyphs"
 

--- a/docs/tmux.rst
+++ b/docs/tmux.rst
@@ -54,7 +54,7 @@ This is by far the most annoying part about using tmux and vim together.
     - cmd-shift-v
   * - tmux copy mode (:kbd:`ctrl-j`:kbd:`[`). You probably want to avoid using
       this inside vim.
-  * - tmux copy mode (:kbd:`ctrl-j`:kbd:`[`). You probably want to avoid using
+    - tmux copy mode (:kbd:`ctrl-j`:kbd:`[`). You probably want to avoid using
       this inside vim.
     - tmux clipboard
     - :kbd:`ctrl-j`:kbd:`]`

--- a/docs/tmux.rst
+++ b/docs/tmux.rst
@@ -3,6 +3,11 @@
 tmux configuration
 ==================
 
+If you're on a Mac and don't have tmux installed, you can use ``./setup.sh
+--install-tmux``. This will create a new environment with tmux and symlink the
+executable to your ``~/opt/bin`` directory. This expects that you've already
+set up conda (with ``./setup.sh --install-mambaforge``).
+
 Here are the general features of the ``.tmux.conf`` file:
 
 -  Set the prefix to be ``Ctrl-j`` (instead of the default ``Ctrl-b``)

--- a/docs/vim.rst
+++ b/docs/vim.rst
@@ -532,12 +532,16 @@ Once you have the terminal up and running, write some R code in the text file
 buffer. To test, you can send lines over using any of the following methods:
 
 1. ``gxx`` to send the current line to R
+
 2. Highlight some lines (``Shift-V`` in vim gets you to visual select
    mode), ``gx`` sends them and then jumps to the terminal.
-4. Inside a code chunk, ``,cd`` sends the entire code chunk and then
-3  jumps to the next one. This way you can ``,cd`` your way through an
+
+3. Inside a code chunk, ``,cd`` sends the entire code chunk and then
+
+4  jumps to the next one. This way you can ``,cd`` your way through an
    Rmd
-4. ``,k`` to render the current Rmd to HTML.
+
+5. ``,k`` to render the current Rmd to HTML.
 
 Troubleshooting
 ~~~~~~~~~~~~~~~

--- a/setup.sh
+++ b/setup.sh
@@ -527,9 +527,18 @@ elif [ $task == "--set-up-vim-plugins" ]; then
     vim_dest=~/.vim/autoload/plug.vim
     download https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim $nvim_dest
     download https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim $vim_dest
+
     echo
-    printf "${YELLOW}Please open nvim and/or vim and run :PlugInstall${UNSET}\n"
+    ok "vim (/usr/bin/vim) will now open, install plugins by running :PlugInstall, and then quit."
     echo
+    /usr/bin/vim -c ':PlugInstall' -c ':bunload 1' -c ':q'
+
+    echo
+    ok "nvim (~/opt/bin/nvim) will now open, install plugins by running :PlugInstall, and then quit"
+    echo
+    ~/opt/bin/nvim -c ':PlugInstall' -c ':bunload 1' -c ':q'
+
+    printf "${YELLOW}In the future if you add plugins to your vim/nvim config, run :PlugInstall${UNSET}\n"
 
 elif [ $task == "--mac-stuff" ]; then
     ok "Sets the shell to be bash, and silences the warning about zsh being the default by adding an env var to ~/.extra"

--- a/setup.sh
+++ b/setup.sh
@@ -366,6 +366,8 @@ check_opt_bin_in_path () {
 # they are not
 install_env_and_symlink () {
 
+    eval "$(conda shell.bash hook)"
+
     # sometimes conda can complain about env vars being unset
     set +u
     ENVNAME=$1
@@ -373,7 +375,7 @@ install_env_and_symlink () {
     EXECUTABLE=$3
 
     can_make_conda_env $ENVNAME
-    conda create -y -n $ENVNAME $CONDAPKG
+    mamba create -y -n $ENVNAME $CONDAPKG
     ln -sf "$CONDA_LOCATION/envs/$ENVNAME/bin/$EXECUTABLE" $HOME/opt/bin/$EXECUTABLE
     printf "${YELLOW}Installed $HOME/opt/bin/$EXECUTABLE${UNSET}\n"
     check_opt_bin_in_path

--- a/setup.sh
+++ b/setup.sh
@@ -90,6 +90,24 @@ function showHelp() {
     printf "   ${BLUE}Documentation: https://daler.github.io/dotfiles/${UNSET}\n"
     echo
 
+    header "RECOMMENDED ORDER:"
+    echo "    1)  ./setup.sh --dotfiles"
+    echo "    2)  CLOSE TERMINAL, OPEN A NEW ONE"
+    echo "    3)  ./setup.sh --install-neovim"
+    echo "    4)  ./setup.sh --set-up-vim-plugins"
+    echo "    5)  ./setup.sh --install-conda"
+    echo "    6)  ./setup.sh --set-up-bioconda"
+    echo "    7)  ./setup.sh --install-fzf"
+    echo "    8)  ./setup.sh --install-ripgrep"
+    echo "    9)  ./setup.sh --install-visidata"
+    echo "    10) ./setup.sh --install-fzf"
+    echo
+    echo "  On Mac:"
+    echo "       ./setup.sh --mac-stuff"
+    echo "       ./setup.sh --install-tmux"
+    echo ""
+    echo "  Then browse the other options below to see what else is available/useful."
+
     header "dotfiles:"
 
     cmd "--diffs" \

--- a/setup.sh
+++ b/setup.sh
@@ -448,6 +448,7 @@ elif [ $task == "--install-mambaforge" ]; then
     download "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh" mambaforge.sh
     bash mambaforge.sh -b -p $MAMBAFORGE_DIR
     rm mambaforge.sh
+    printf "${YELLOW}conda installed at ${MAMBAFORGE_DIR}/condabin. Make sure it's on your path.${UNSET}\n"
 
 elif [ $task == "--set-up-bioconda" ]; then
     ok "Sets up Bioconda by adding the dependent channels in the correct order"

--- a/setup.sh
+++ b/setup.sh
@@ -20,7 +20,7 @@ fi
 set -eo pipefail
 
 # Change tool versions here
-VISIDATA_VERSION=2.8
+VISIDATA_VERSION=2.11
 HUB_VERSION=2.14.2
 NVIM_VERSION=0.7.0
 RG_VERSION=13.0.0

--- a/setup.sh
+++ b/setup.sh
@@ -147,8 +147,8 @@ function showHelp() {
 
     header "conda setup:"
 
-    cmd "--install-mambaforge" \
-        "Install Mambaforge (conda installation)" \
+    cmd "--install-conda" \
+        "Install conda using the Mambaforge installation" \
         "Homepage: https://github.com/conda-forge/miniforge"
 
     cmd "--set-up-bioconda" \
@@ -439,8 +439,8 @@ elif [ $task == "--install-docker" ]; then
     echo
     echo "Please log out and then log back in again to be able to use docker as $USER instead of root"
 
-elif [ $task == "--install-mambaforge" ]; then
-    ok "Installs mambaforge"
+elif [ $task == "--install-conda" ]; then
+    ok "Installs conda using the Mambaforge installation"
 
     # On Biowulf/Helix, if we install into $HOME then the installation might
     # larger than the quota for the home directory. Instead, install to user's

--- a/setup.sh
+++ b/setup.sh
@@ -147,6 +147,9 @@ function showHelp() {
 
     header "Installations for local host only"
 
+    cmd "--mac-stuff" \
+        "Make some Mac-specific settings"
+
     cmd "--powerline" \
         "Install powerline fonts. Powerline fonts include the" \
         "fancy glyphs used for the vim-airline status bar." \
@@ -516,6 +519,10 @@ elif [ $task == "--set-up-vim-plugins" ]; then
     printf "${YELLOW}Please open nvim and/or vim and run :PlugInstall${UNSET}\n"
     echo
 
+elif [ $task == "--mac-stuff" ]; then
+    ok "Sets the shell to be bash, and silences the warning about zsh being the default by adding an env var to ~/.extra"
+    chsh -s /bin/bash
+    echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.extra
 
 elif [ $task == "--powerline" ]; then
     ok "Installs patched powerline fonts from https://github.com/powerline/fonts for use with vim-airline"

--- a/setup.sh
+++ b/setup.sh
@@ -528,15 +528,18 @@ elif [ $task == "--set-up-vim-plugins" ]; then
     download https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim $nvim_dest
     download https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim $vim_dest
 
-    echo
-    ok "vim (/usr/bin/vim) will now open, install plugins by running :PlugInstall, and then quit."
-    echo
-    /usr/bin/vim -c ':PlugInstall' -c ':bunload 1' -c ':q'
+    VIM=$(which vim)
+    NVIM=$(which nvim)
 
     echo
-    ok "nvim (~/opt/bin/nvim) will now open, install plugins by running :PlugInstall, and then quit"
+    ok "vim ($VIM) will now open, install plugins by running :PlugInstall, and then quit."
     echo
-    ~/opt/bin/nvim -c ':PlugInstall' -c ':bunload 1' -c ':q'
+    $VIM -c ':PlugInstall' -c ':bunload 1' -c ':q'
+
+    echo
+    ok "nvim ($NVIM) will now open, install plugins by running :PlugInstall, and then quit"
+    echo
+    $NVIM -c ':PlugInstall' -c ':bunload 1' -c ':q'
 
     printf "${YELLOW}In the future if you add plugins to your vim/nvim config, run :PlugInstall${UNSET}\n"
 

--- a/setup.sh
+++ b/setup.sh
@@ -101,6 +101,7 @@ function showHelp() {
     echo "    8)  ./setup.sh --install-ripgrep"
     echo "    9)  ./setup.sh --install-visidata"
     echo "    10) ./setup.sh --install-fzf"
+    echo "    11) ./setup.sh --install-pyp"
     echo
     echo "  On Mac:"
     echo "       ./setup.sh --mac-stuff"

--- a/setup.sh
+++ b/setup.sh
@@ -170,6 +170,9 @@ function showHelp() {
 
     header "Installations for any host:"
 
+    cmd "--install-tmux" \
+        "Install tmux"
+
     cmd "--install-bat" \
         "bat is like cat, but adds things like syntax highlighting," \
         "showing lines changed based on git, and showing non-printable" \
@@ -528,6 +531,7 @@ elif [ $task == "--powerline" ]; then
 # ----------------------------------------------------------------------------
 # Individual --install commands
 
+
 elif [ $task == "--install-meld" ]; then
     ok "Downloads .dmg for meld, install into ~/opt/meld and then writes ~/opt/bin/meld wrapper"
     if [[ $OSTYPE == darwin* ]]; then
@@ -578,6 +582,11 @@ elif [ $task == "--install-fd" ]; then
     printf "${YELLOW}Installed to ~/opt/bin/fd${UNSET}\n"
     check_opt_bin_in_path
 
+elif [ $task == "--install-tmux" ]; then
+    ok "Install tmux into a new conda env and symlink to ~/opt/bin/tmux"
+    install_env_and_symlink tmux tmux tmux
+    printf "${YELLOW}Installed to ~/opt/bin/tmux${UNSET}\n"
+    check_opt_bin_in_path
 
 elif [ $task == "--install-vd" ]; then
     ok "Install visidata (https://visidata.org/) into a new conda env and symlink to ~/opt/bin/vd"

--- a/setup.sh
+++ b/setup.sh
@@ -653,7 +653,7 @@ elif [ $task == "--install-radian" ]; then
     set +u
     # Note: radian needs R installed to compile the rchitect dependency. It
     # is unclear whether radian is dependent on a particular R version.
-    conda create -y -n radian python r
+    mamba create -y -n radian python r
     conda activate radian
     pip install radian
     ln -sf $CONDA_LOCATION/envs/radian/bin/radian $HOME/opt/bin/radian
@@ -758,7 +758,7 @@ elif [ $task == "--install-pyp" ]; then
     ok "Install pyp (https://github.com/hauntsaninja/pyp) into ~/opt/bin"
     set +u
     can_make_conda_env "pyp"
-    conda create -y -n pyp python
+    mamba create -y -n pyp python
     conda activate pyp
     pip install pypyp==${PYP_VERSION}
     ln -sf $(which pyp) $HOME/opt/bin/pyp

--- a/setup.sh
+++ b/setup.sh
@@ -132,9 +132,9 @@ function showHelp() {
 
     header "conda setup:"
 
-    cmd "--install-miniconda" \
-        "Install Miniconda." \
-        "Homepage: https://docs.conda.io/en/latest/miniconda.html" \
+    cmd "--install-mambaforge" \
+        "Install Mambaforge (conda installation)" \
+        "Homepage: https://github.com/conda-forge/miniforge"
 
     cmd "--set-up-bioconda" \
         "Set up bioconda channel priorities." \
@@ -420,52 +420,26 @@ elif [ $task == "--install-docker" ]; then
     echo
     echo "Please log out and then log back in again to be able to use docker as $USER instead of root"
 
-
-elif [ $task == "--install-miniconda" ]; then
+elif [ $task == "--install-mambaforge" ]; then
+    ok "Installs mambaforge"
 
     # On Biowulf/Helix, if we install into $HOME then the installation might
     # larger than the quota for the home directory. Instead, install to user's
     # data directory which has much more space.
-    MINICONDA_DIR=$HOME/miniconda3
+    MAMBAFORGE_DIR=$HOME/mambaforge
     if [[ $HOSTNAME == "helix.nih.gov" || $HOSTNAME == "biowulf.nih.gov" ]]; then
-        MINICONDA_DIR=/data/$USER/miniconda3
+        MAMBAFORGE_DIR=/data/$USER/mambaforge
 
-        # Newer versions of miniconda cannot run from a noexec directory which
-        # may be the case on some hosts.  See discussion at
+        # Newer versions of the installer cannot run from a noexec directory
+        # which may be the case on some hosts.  See discussion at
         # https://github.com/ContinuumIO/anaconda-issues/issues/11154#issuecomment-535571313
-        export TMPDIR=/data/$USER/miniconda3-tmp
+        export TMPDIR=/data/$USER/mambaforge
         mkdir -p $TMPDIR
     fi
 
-    ok "Installs Miniconda
-       - installs to $MINICONDA_DIR
-       - runs 'conda init bash'
-       - prints notes and recommendations for next steps
-    "
-    if [[ $OSTYPE == darwin* ]]; then
-        download https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh miniconda.sh
-    else
-        download https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh miniconda.sh
-    fi
-
-    set -x
-    bash miniconda.sh -b -p $MINICONDA_DIR
-    rm miniconda.sh
-    set +x
-    $MINICONDA_DIR/bin/conda init bash
-
-    if [ -e /data/$USER/miniconda3-tmp ]; then
-        rm -r /data/$USER/miniconda3-tmp
-    fi
-
-    printf "${YELLOW}Miniconda installed to $MINICONDA_DIR.${UNSET}\n"
-    printf "${YELLOW}   and then ran \"$MINICONDA_DIR/bin/conda init bash\", \n${UNSET}"
-    printf "${YELLOW}   which added lines to your .bashrc. You should check out those lines.${UNSET}\n\n"
-
-    if [[ $OSTYPE == darwin* ]]; then
-        printf "${YELLOW}Looks like you're on a Mac: in this case, look in ~/.bash_profile for the\n"
-        printf "lines added by conda init bash. Move them from ~/.bash_profile to ~/.bashrc.${UNSET}\n\n"
-    fi
+    download "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh" mambaforge.sh
+    bash mambaforge.sh -b -p $MAMBAFORGE_DIR
+    rm mambaforge.sh
 
 elif [ $task == "--set-up-bioconda" ]; then
     ok "Sets up Bioconda by adding the dependent channels in the correct order"

--- a/setup.sh
+++ b/setup.sh
@@ -116,9 +116,6 @@ function showHelp() {
     cmd "--vim-diffs" \
         "Inspect diffs between repo and home, using vim -d"
 
-    cmd "--graphical-diffs" \
-        "Inspect diffs between repo and home, using meld"
-
     cmd "--dotfiles" \
         "Replaces files in $HOME with files from this directory"
 
@@ -184,10 +181,6 @@ function showHelp() {
     cmd "--install-docker" \
         "Installs docker and adds current user to new docker group." \
         "(Needs root, Linux only)"
-
-    cmd "--install-meld" \
-        "(Mac only). meld is a graphical diff tool, extremely useful" \
-        "for 3-way diffs"
 
     header "Installations for any host:"
 
@@ -557,24 +550,6 @@ elif [ $task == "--powerline" ]; then
 # ----------------------------------------------------------------------------
 # Individual --install commands
 
-
-elif [ $task == "--install-meld" ]; then
-    ok "Downloads .dmg for meld, install into ~/opt/meld and then writes ~/opt/bin/meld wrapper"
-    if [[ $OSTYPE == darwin* ]]; then
-        download https://github.com/yousseb/meld/releases/download/osx-14/meldmerge.dmg /tmp/meldmerge.dmg
-        set -x
-        mounted=$(hdiutil attach /tmp/meldmerge.dmg | tail -1 | cut -f3)
-        cp -r "$mounted" ~/opt/meld
-        echo "~/opt/meld/Meld.app/Contents/MacOS/Meld \"\$@\"" > ~/opt/bin/meld
-        hdiutil detach "$mounted"
-        set +x
-    else
-        echo
-        printf "${RED}--install-meld currently only supported on Mac.\n"
-        printf "Use --apt-installs on Linux or '/usr/bin/python /usr/bin/meld' on Biowulf${UNSET}\n"
-    fi
-
-
 elif [ $task == "--install-fzf" ]; then
     ok "Installs fzf (https://github.com/junegunn/fzf)"
     (
@@ -608,11 +583,13 @@ elif [ $task == "--install-fd" ]; then
     printf "${YELLOW}Installed to ~/opt/bin/fd${UNSET}\n"
     check_opt_bin_in_path
 
+
 elif [ $task == "--install-tmux" ]; then
     ok "Install tmux into a new conda env and symlink to ~/opt/bin/tmux"
     install_env_and_symlink tmux tmux tmux
     printf "${YELLOW}Installed to ~/opt/bin/tmux${UNSET}\n"
     check_opt_bin_in_path
+
 
 elif [ $task == "--install-vd" ]; then
     ok "Install visidata (https://visidata.org/) into a new conda env and symlink to ~/opt/bin/vd"

--- a/setup.sh
+++ b/setup.sh
@@ -531,17 +531,23 @@ elif [ $task == "--set-up-vim-plugins" ]; then
     VIM=$(which vim)
     NVIM=$(which nvim)
 
-    echo
-    ok "vim ($VIM) will now open, install plugins by running :PlugInstall, and then quit."
-    echo
-    $VIM -c ':PlugInstall' -c ':bunload 1' -c ':q'
+    if [ $MANUAL_PLUG_INSTALL != 1 ]; then
+        echo
+        ok "vim ($VIM) will now open, install plugins by running :PlugInstall, and then quit."
+        echo
+        $VIM -c ':PlugInstall' -c ':bunload 1' -c ':q'
 
-    echo
-    ok "nvim ($NVIM) will now open, install plugins by running :PlugInstall, and then quit"
-    echo
-    $NVIM -c ':PlugInstall' -c ':bunload 1' -c ':q'
+        echo
+        ok "nvim ($NVIM) will now open, install plugins by running :PlugInstall, and then quit"
+        echo
+        $NVIM -c ':PlugInstall' -c ':bunload 1' -c ':q'
 
-    printf "${YELLOW}In the future if you add plugins to your vim/nvim config, run :PlugInstall${UNSET}\n"
+        printf "${YELLOW}In the future if you add plugins to your vim/nvim config, run :PlugInstall${UNSET}\n"
+    else
+        printf "${YELLOW}Please open vim and/or nvim, run :PlugInstall${UNSET}\n"
+    fi
+
+
 
 elif [ $task == "--mac-stuff" ]; then
     ok "Sets the shell to be bash, and silences the warning about zsh being the default by adding an env var to ~/.extra"

--- a/setup.sh
+++ b/setup.sh
@@ -269,7 +269,7 @@ if [ -z $DOTFILES_FORCE ]; then
     DOTFILES_FORCE=false
 fi
 
-set -eou pipefail
+set -eo pipefail
 
 # The CLI is pretty minimal -- we're just doing an exact string match
 task=$1

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ set -eo pipefail
 # Change tool versions here
 VISIDATA_VERSION=2.11
 HUB_VERSION=2.14.2
-NVIM_VERSION=0.7.0
+NVIM_VERSION=0.9.0
 RG_VERSION=13.0.0
 BAT_VERSION=0.19.0
 JQ_VERSION=1.6
@@ -486,7 +486,7 @@ elif [ $task == "--install-neovim" ]; then
         download https://github.com/neovim/neovim/releases/download/v${NVIM_VERSION}/nvim-macos.tar.gz nvim-macos.tar.gz
         tar -xzf nvim-macos.tar.gz
         mkdir -p "$HOME/opt/bin"
-        mv nvim-osx64 "$HOME/opt/neovim"
+        mv nvim-macos "$HOME/opt/neovim"
     else
         download https://github.com/neovim/neovim/releases/download/v${NVIM_VERSION}/nvim-linux64.tar.gz nvim-linux64.tar.gz
         tar -xzf nvim-linux64.tar.gz
@@ -531,7 +531,7 @@ elif [ $task == "--set-up-vim-plugins" ]; then
     VIM=$(which vim)
     NVIM=$(which nvim)
 
-    if [ $MANUAL_PLUG_INSTALL != 1 ]; then
+    if [ ${MANUAL_PLUG_INSTALL:=0} != 1 ]; then
         echo
         ok "vim ($VIM) will now open, install plugins by running :PlugInstall, and then quit."
         echo


### PR DESCRIPTION
- add `ca` and `conda_deactivate_all` functions, and run `conda_deactivate_all` when starting a new tmux session or pane
- add documentation for this new conda setup
- improved `start_agent` to use Mac login
- new command `--mac-stuff` for post-installation Mac 
- new command `--install-tmux` command esp useful for Mac
- use Mambaforge when installing conda; change `--install-miniconda` to `--install-conda`; this support Mac ARM64 architecture
- when running `--set-up-vim-plugins`, run `:PlugInstall` automatically unless `MANUAL_PLUG_INSTALL=1`
- add recommended order of operations in `setup.sh`
