### PR TITLE
Post lua tweaks

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -168,29 +168,38 @@ vim.api.nvim_create_autocmd("TextYankPost", {
   pattern = "*",
 })
 
--- From https://github.com/nvim-tree/nvim-tree.lua/wiki/Auto-Close. If the last
--- buffer open is an nvim-tree buffer, then close it and quit.
+-- Modified from https://github.com/nvim-tree/nvim-tree.lua/wiki/Auto-Close.
+-- If the last buffer(s) open are nvim-tree or trouble.nvim or aerial, then close them all and quit.
 vim.api.nvim_create_autocmd("QuitPre", {
   callback = function()
-    local tree_wins = {}
+    local close_wins = {}
     local floating_wins = {}
     local wins = vim.api.nvim_list_wins()
     for _, w in ipairs(wins) do
       local bufname = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(w))
-      if bufname:match("NvimTree_") ~= nil then
-        table.insert(tree_wins, w)
+      if bufname:match("NvimTree_") ~= nil then  -- nvim-tree buffer
+        table.insert(close_wins, w)
       end
-      if vim.api.nvim_win_get_config(w).relative ~= '' then
+      if bufname:match("Trouble") ~= nil then    -- trouble.nvim buffer
+        table.insert(close_wins, w)
+      end
+      if bufname:match("Scratch") ~= nil then    -- aerial buffer
+        table.insert(close_wins, w)
+      end
+      if vim.api.nvim_win_get_config(w).relative ~= "" then -- floating windows
         table.insert(floating_wins, w)
       end
     end
-    if 1 == #wins - #floating_wins - #tree_wins then
-      -- Should quit, so we close all invalid windows.
-      for _, w in ipairs(tree_wins) do
+
+    -- If the buffer we are closing during this QuitPre action is the only one
+    -- that does not match the above patterns, then consider it the last text buffer,
+    -- and close all other buffers.
+    if 1 == #wins - #floating_wins - #close_wins then
+      for _, w in ipairs(close_wins) do
         vim.api.nvim_win_close(w, true)
       end
     end
-  end
+  end,
 })
 
 -- Modifications to the zenburn colorscheme.

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,7 +1,7 @@
 -- Lua config for neovim. Coming from Vim lanuage? See
 -- https://neovim.io/doc/user/lua.html for the basics.
 
--- leader must be set before plugins are installed
+-- leader must be set before plugins are set up.
 vim.cmd("let mapleader=','") -- Re-map leader from default \ to , (comma)
 vim.cmd("let maplocalleader = '\\'") -- Local leader becomes \.
 
@@ -26,6 +26,7 @@ vim.opt.rtp:prepend(lazypath)
 --
 -- Plugins.
 -- Plugins are handled separately, see the lua/plugins.lua file.
+-- This command tells lazy.nvim, the plugin manager, where to find that file.
 --
 require("lazy").setup("plugins")
 
@@ -146,6 +147,7 @@ vim.api.nvim_create_autocmd("Filetype", {
   end,
 })
 
+-- Tell nvim about the snakemake filetype
 vim.filetype.add({
   filename = {
     ["Snakefile"] = "snakemake",
@@ -155,7 +157,7 @@ vim.filetype.add({
     ["*.snakefile"] = "snakemake",
     ["*.snakemake"] = "snakemake",
     ["Snakefile*"] = "snakemake",
-  }
+  },
 })
 
 -- Highlight yanked text
@@ -202,8 +204,8 @@ vim.api.nvim_create_autocmd("QuitPre", {
 if vim.api.nvim_exec("colorscheme", true) == "zenburn.nvim" then
   -- If there's a good highlight existing, link to that
   vim.api.nvim_set_hl(0, "@variable", { link = "Normal" })
-  vim.api.nvim_set_hl(0, "diffAdded", { fg="#9ECE9E", bg="#313C36" })
-  vim.api.nvim_set_hl(0, "diffRemoved", { fg="#ECBCBC", bg="#41363C"})
+  vim.api.nvim_set_hl(0, "diffAdded", { fg = "#9ECE9E", bg = "#313C36" })
+  vim.api.nvim_set_hl(0, "diffRemoved", { fg = "#ECBCBC", bg = "#41363C" })
   vim.api.nvim_set_hl(0, "diffLine", { link = "MoreMsg" })
 
   vim.cmd("highlight LineNr guifg=#959898 guibg=#353535")

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -106,7 +106,6 @@ vim.keymap.set("n", "[b", ":bprevious<CR>", { desc = "Previous buffer" })
 vim.keymap.set("n", "]b", ":bnext<CR>", { desc = "Next buffer" })
 vim.keymap.set("n", "H", ":bprevious<CR>", { desc = "Previous buffer" })
 vim.keymap.set("n", "L", ":bnext<CR>", { desc = "Next buffer" })
-vim.keymap.set("n", "<leader>b", ":buffers<CR>:buffer<Space>", { desc = "Select buffer" })
 
 -- Keymappings for navigating terminals.
 -- <leader>q and <leader>w move to left and right windows respectively. Useful

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -81,6 +81,11 @@ vim.cmd("set guicursor=i:block") -- Always use block cursor. In some terminals a
 -- lua/plugins.lua. Many keymappings have descriptions which will show up in
 -- which-key.
 --
+-- 
+local wk = require('which-key')
+wk.register( { ["<leader>c"] = { name = "+code" } } )
+wk.register( { ["<leader>f"] = { name = "+file or +find" } } )
+
 vim.keymap.set("t", "<Esc>", "<C-\\><C-n>") -- Fix <Esc> in terminal buffer
 vim.keymap.set("n", "<Leader>H", ":set hlsearch!<CR>", { desc = "Toggle search highlight" })
 vim.keymap.set("n", "<leader>W", ":%s/\\s\\+$//<cr>:let @/=''<CR>", { desc = "Clean trailing whitespace" })

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -195,7 +195,8 @@ vim.api.nvim_create_autocmd("QuitPre", {
 
 -- Modifications to the zenburn colorscheme.
 -- Collectively, this makes line numbers more obvious, fixes some diff
--- coloring, and makes bash and python highlighting look more like the older
+-- coloring, makes matched parentheses much more obvious, and makes
+-- bash and python highlighting look more like the older
 -- zenburn. Some hints for tweaking colorschemes:
 --
 --  *  Use :Inspect to see what highlight group the cursor is over.
@@ -208,6 +209,7 @@ if vim.api.nvim_exec("colorscheme", true) == "zenburn.nvim" then
   vim.api.nvim_set_hl(0, "diffRemoved", { fg = "#ECBCBC", bg = "#41363C" })
   vim.api.nvim_set_hl(0, "diffLine", { link = "MoreMsg" })
 
+  vim.cmd("highlight MatchParen guifg=#b2ff45")
   vim.cmd("highlight LineNr guifg=#959898 guibg=#353535")
   vim.cmd("highlight CursorLineNr guifg=#f2f48d guibg=#2f2f2f")
   vim.cmd("highlight IncSearch guifg=#f8f893 guibg=#385f38")
@@ -223,7 +225,6 @@ if vim.api.nvim_exec("colorscheme", true) == "zenburn.nvim" then
   vim.cmd("highlight IblScope guifg=#efefaf")
   vim.cmd("highlight @ibl.scope.char.1 guifg=#efefaf")
   vim.cmd("highlight Beacon guibg=white ctermbg=15")
-
 end
 
 -- vim: nowrap

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -201,38 +201,4 @@ vim.api.nvim_create_autocmd("QuitPre", {
   end,
 })
 
--- Modifications to the zenburn colorscheme.
--- Collectively, this makes line numbers more obvious, fixes some diff
--- coloring, makes matched parentheses much more obvious, and makes
--- bash and python highlighting look more like the older
--- zenburn. Some hints for tweaking colorschemes:
---
---  *  Use :Inspect to see what highlight group the cursor is over.
---  *  Use :Telescope higlight to search for it and find the current setting
-
-if vim.api.nvim_exec("colorscheme", true) == "zenburn.nvim" then
-  -- If there's a good highlight existing, link to that
-  vim.api.nvim_set_hl(0, "@variable", { link = "Normal" })
-  vim.api.nvim_set_hl(0, "diffAdded", { fg = "#9ECE9E", bg = "#313C36" })
-  vim.api.nvim_set_hl(0, "diffRemoved", { fg = "#ECBCBC", bg = "#41363C" })
-  vim.api.nvim_set_hl(0, "diffLine", { link = "MoreMsg" })
-
-  vim.cmd("highlight MatchParen guifg=#b2ff45")
-  vim.cmd("highlight LineNr guifg=#959898 guibg=#353535")
-  vim.cmd("highlight CursorLineNr guifg=#f2f48d guibg=#2f2f2f")
-  vim.cmd("highlight IncSearch guifg=#f8f893 guibg=#385f38")
-  vim.cmd("highlight Comment cterm=italic gui=italic")
-  vim.cmd("highlight DiffDelete guifg=#9f8888 guibg=#464646")
-  vim.cmd("highlight Constant guifg=#dcdccc gui=bold")
-  vim.cmd("highlight Boolean guifg=#FFCFAF gui=bold")
-  vim.cmd("highlight Function guifg=#f6f6ab")
-  vim.cmd("highlight @punctuation.bracket.bash guifg=#FFCFAF")
-  vim.cmd("highlight @punctuation.special.bash guifg=#FFCFAF")
-  vim.cmd("highlight @constant.bash guifg=#FFCFAF")
-  vim.cmd("highlight @variable.bash guifg=#FFCFAF")
-  vim.cmd("highlight IblScope guifg=#efefaf")
-  vim.cmd("highlight @ibl.scope.char.1 guifg=#efefaf")
-  vim.cmd("highlight Beacon guibg=white ctermbg=15")
-end
-
 -- vim: nowrap

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -5,6 +5,10 @@
 vim.cmd("let mapleader=','") -- Re-map leader from default \ to , (comma)
 vim.cmd("let maplocalleader = '\\'") -- Local leader becomes \.
 
+-- This allows nvim-tree to be used when opening a directory in nvim.
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
 -- Bootstrap lazy.nvim in case it's not already installed.
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not vim.loop.fs_stat(lazypath) then

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -8,6 +8,7 @@ vim.cmd("let maplocalleader = '\\'") -- Local leader becomes \.
 -- This allows nvim-tree to be used when opening a directory in nvim.
 vim.g.loaded_netrw = 1
 vim.g.loaded_netrwPlugin = 1
+vim.cmd("set termguicolors") -- use full color in colorschemes
 
 -- Bootstrap lazy.nvim in case it's not already installed.
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
@@ -35,7 +36,6 @@ require("lazy").setup("plugins")
 -- Add your favorite colorscheme to lua/plugins.lua, and use it here.
 --
 vim.cmd("colorscheme zenburn") -- bottom of this file has some tweaks to zenburn
-vim.cmd("set termguicolors") -- use full color in colorschemes
 
 -- Uncomment these lines if you use a terminal that does not support true color:
 -- vim.cmd("colorscheme onedark")

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -180,7 +180,10 @@ return {
           enable = true,
           disable = { "markdown", "rmarkdown" }, -- let pandoc handle highlighting for these
         },
-        indent = { enable = true },
+        indent = {
+          enable = true,
+          disable = { "python", "snakemake" }, -- let vim-python-pep8-indent handle this
+        },
         ensure_installed = {
           "bash",
           "css",

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -23,6 +23,8 @@ return {
   { "stsewd/sphinx.nvim", ft = "rst" }, -- syntax/grammar for Sphinx (ReST) documentation
   { "folke/which-key.nvim", lazy = false, config = true, }, -- pop up a window showing possible keybindings
   { "phha/zenburn.nvim", lazy = false, priority = 1000 }, -- colorscheme
+  { "morhetz/gruvbox", enabled = false }, -- example of an alternative colorscheme, here disabled
+  { "joshdick/onedark.vim", lazy = false }, -- another colorscheme, here enabled as a fallback for terminals with no true-color support like Terminal.app.
   {
     "EdenEast/nightfox.nvim",
     lazy = false,
@@ -35,8 +37,6 @@ return {
       })
     end,
   },
-  { "morhetz/gruvbox", enabled = false }, -- example of an alternative colorscheme, here disabled
-  { "joshdick/onedark.vim" }, -- another colorscheme, here enabled as a fallback for terminals with no true-color support like Terminal.app.
 
   {
     "nvim-tree/nvim-tree.lua", -- file browser
@@ -73,12 +73,12 @@ return {
           local previewer = require("telescope.themes").get_dropdown({ previewer = false })
           require("telescope.builtin").find_files(previewer)
         end,
-        desc = "Find files",
+        desc = "[f]ind [f]iles",
       },
-      { "<leader>fg", "<cmd>Telescope live_grep<cr>", desc = "Live grep in directory" },
+      { "<leader>fg", "<cmd>Telescope live_grep<cr>", desc = "[f]ind with [g]rep in directory" },
       { "<leader>/", "<cmd>Telescope current_buffer_fuzzy_find<cr>", desc = "Fuzzy find in buffer" },
-      { "<leader>fc", "<cmd>Telescope treesitter<CR>", desc = "Find code object" },
-      { "<leader>fo", "<cmd>Telescope oldfiles<CR>", desc = "Find recently-opened files" },
+      { "<leader>fc", "<cmd>Telescope treesitter<CR>", desc = "[f]ind [c]ode object" },
+      { "<leader>fr", "<cmd>Telescope oldfiles<CR>", desc = "[f]ind [r]ecently-opened files" },
     },
   },
 
@@ -147,7 +147,7 @@ return {
             "n",
             "<leader>k",
             ":TermExec cmd='rmarkdown::render(\"%:p\")'<CR>",
-            { desc = "Render RMarkdown to HTML" }
+            { desc = "Render RMar[k]down to HTML" }
           )
         end,
       })
@@ -245,9 +245,9 @@ return {
 
     opts = { layout = { default_direction = "prefer_left" } },
     keys = {
-      { "{", "<cmd>AerialPrev<CR>", buffer = bufnr, desc = "Prev code symbol" },
-      { "}", "<cmd>AerialNext<CR>", buffer = bufnr, desc = "Next code symbol" },
-      { "<leader>a", "<cmd>AerialToggle<CR>", buffer = bufnr, desc = "Toggle aerial nav" },
+      { "{", "<cmd>AerialPrev<CR>", desc = "Prev code symbol" },
+      { "}", "<cmd>AerialNext<CR>", desc = "Next code symbol" },
+      { "<leader>a", "<cmd>AerialToggle<CR>", desc = "Toggle [a]erial nav" },
     },
   },
 
@@ -264,22 +264,22 @@ return {
           vim.keymap.set(mode, l, r, { buffer = buffer, desc = desc })
         end
 
-        map("n", "]h", gs.next_hunk, "Next Hunk")
-        map("n", "[h", gs.prev_hunk, "Prev Hunk")
-        map({ "n", "v" }, "<leader>hs", ":Gitsigns stage_hunk<CR>", "Stage Hunk")
-        map({ "n", "v" }, "<leader>hr", ":Gitsigns reset_hunk<CR>", "Reset Hunk")
-        map("n", "<leader>hS", gs.stage_buffer, "Stage Buffer")
-        map("n", "<leader>hu", gs.undo_stage_hunk, "Undo Stage Hunk")
-        map("n", "<leader>hR", gs.reset_buffer, "Reset Buffer")
-        map("n", "<leader>hp", gs.preview_hunk, "Preview Hunk")
+        map("n", "]h", gs.next_hunk, "Next hunk")
+        map("n", "[h", gs.prev_hunk, "Prev hunk")
+        map({ "n", "v" }, "<leader>hs", ":Gitsigns stage_hunk<CR>", "Stage hunk")
+        map({ "n", "v" }, "<leader>hr", ":Gitsigns reset_hunk<CR>", "Reset hunk")
+        map("n", "<leader>hS", gs.stage_buffer, "Stage buffer")
+        map("n", "<leader>hu", gs.undo_stage_hunk, "Undo Stage hunk")
+        map("n", "<leader>hR", gs.reset_buffer, "Reset buffer")
+        map("n", "<leader>hp", gs.preview_hunk, "Preview hunk")
         map("n", "<leader>hb", function()
           gs.blame_line({ full = true })
-        end, "Blame Line")
-        map("n", "<leader>hd", gs.diffthis, "Diff This")
+        end, "Blame line")
+        map("n", "<leader>hd", gs.diffthis, "Diff this")
         map("n", "<leader>hD", function()
           gs.diffthis("~")
         end, "Diff This ~")
-        map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>", "GitSigns Select Hunk")
+        map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>", "GitSigns Select hunk")
       end,
     },
   },

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -40,12 +40,8 @@ return {
 
   {
     "nvim-tree/nvim-tree.lua", -- file browser
-    config = function()
-      require("nvim-tree").setup({
-        disable_netrw = false,
-        hijack_netrw = true,
-      })
-    end,
+    lazy = false,
+    config = true,
     keys = {
       { "<leader>fbc", "<cmd>NvimTreeClose<CR>", desc = "[f]ile [b]rowser [c]lose (nvim-tree)" },
       { "<leader>fbo", "<cmd>NvimTreeFocus<CR>", desc = "[f]ile [b]rowser [o]pen (or focus if open)" },

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -21,13 +21,16 @@ return {
   { "tpope/vim-fugitive", cmd = "Git", lazy = true }, -- convenient git interface, with incremental commits
   { "sindrets/diffview.nvim", cmd = { "DiffviewOpen", "DiffviewFileHistory" } }, -- nice diff interface
   { "stsewd/sphinx.nvim", ft = "rst" }, -- syntax/grammar for Sphinx (ReST) documentation
-  { "folke/which-key.nvim", lazy = false, config = true }, -- pop up a window showing possible keybindings
+  { "folke/which-key.nvim", lazy = false, config = true, }, -- pop up a window showing possible keybindings
   { "phha/zenburn.nvim", lazy = false, priority = 1000 }, -- colorscheme
-  { "EdenEast/nightfox.nvim", lazy = false, priority = 1000,
-    config = function ()
-      require('nightfox').setup({
+  {
+    "EdenEast/nightfox.nvim",
+    lazy = false,
+    priority = 1000,
+    config = function()
+      require("nightfox").setup({
         options = {
-          styles = { comments = "italic", },
+          styles = { comments = "italic" },
         },
       })
     end,

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -19,12 +19,14 @@ return {
   { "Vimjas/vim-python-pep8-indent", ft = { "python", "snakemake" } }, -- better indentation for python
   { "samoshkin/vim-mergetool", cmd = "MergetoolStart" }, -- easily work with 3-way merge conflicts
   { "tpope/vim-fugitive", cmd = "Git", lazy = true }, -- convenient git interface, with incremental commits
+  { "junegunn/gv.vim", cmd = "GV", dependencies = {"tpope/vim-fugitive"}, lazy = true}, -- graphical git log
   { "sindrets/diffview.nvim", cmd = { "DiffviewOpen", "DiffviewFileHistory" } }, -- nice diff interface
   { "stsewd/sphinx.nvim", ft = "rst" }, -- syntax/grammar for Sphinx (ReST) documentation
   { "folke/which-key.nvim", lazy = false, config = true, }, -- pop up a window showing possible keybindings
   { "daler/zenburn.nvim", lazy = false, priority = 1000 }, -- colorscheme
   { "morhetz/gruvbox", enabled = false }, -- example of an alternative colorscheme, here disabled
   { "joshdick/onedark.vim", lazy = false }, -- another colorscheme, here enabled as a fallback for terminals with no true-color support like Terminal.app.
+  { "norcalli/nvim-colorizer.lua", config = true, lazy = true, cmd = "ColorizerToggle" }, -- color hex codes by their actual color
   {
     "EdenEast/nightfox.nvim", -- family of colorschemes (nightfox, dawnfox, terrafox, etc)
     lazy = false,

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -26,7 +26,7 @@ return {
   { "morhetz/gruvbox", enabled = false }, -- example of an alternative colorscheme, here disabled
   { "joshdick/onedark.vim", lazy = false }, -- another colorscheme, here enabled as a fallback for terminals with no true-color support like Terminal.app.
   {
-    "EdenEast/nightfox.nvim",
+    "EdenEast/nightfox.nvim", -- family of colorschemes (nightfox, dawnfox, terrafox, etc)
     lazy = false,
     priority = 1000,
     config = function()
@@ -69,6 +69,7 @@ return {
       {
         "<leader>ff",
         function()
+          -- use a previewer that doesn't show each file's contents
           local previewer = require("telescope.themes").get_dropdown({ previewer = false })
           require("telescope.builtin").find_files(previewer)
         end,
@@ -120,6 +121,7 @@ return {
     "akinsho/toggleterm.nvim", -- terminal in vim you can send code to
     lazy = false,
     config = function()
+      -- tweak the sizes of the new terminal
       require("toggleterm").setup({
         size = function(term)
           if term.direction == "horizontal" then
@@ -129,9 +131,8 @@ return {
           end
         end,
       })
-      -- Always use insert mode when entering a terminal buffer, even with mouse
-      -- click. NOTE: Clicking with a mouse a second time enters visual select mode,
-      -- just like in a text buffer.
+      -- Always use insert mode when entering a terminal buffer, even with mouse click.
+      -- NOTE: Clicking with a mouse a second time enters visual select mode, just like in a text buffer.
       vim.api.nvim_create_autocmd("BufEnter", {
         pattern = "*",
         callback = function()
@@ -139,6 +140,7 @@ return {
         end,
       })
 
+      -- Only set this for RMarkdown
       vim.api.nvim_create_autocmd("FileType", {
         pattern = "rmarkdown",
         callback = function()
@@ -150,6 +152,8 @@ return {
           )
         end,
       })
+
+      -- Only set this for Python
       vim.api.nvim_create_autocmd("FileType", {
         pattern = "python",
         callback = function()
@@ -234,7 +238,7 @@ return {
     main = "ibl",
     opts = {
       indent = { char = "┊" }, -- make the character a little less dense
-      scope = { exclude = { language = { "markdown", "rst" } } },
+      scope = { exclude = { language = { "markdown", "rst" } } }, -- don't need scope for text docs
     },
   },
 
@@ -254,7 +258,7 @@ return {
   },
 
   {
-    "lewis6991/gitsigns.nvim", -- show changes in git repo
+    "lewis6991/gitsigns.nvim", -- show changes in file, when working in a git repo
     dependencies = {
       "nvim-lua/plenary.nvim",
     },
@@ -287,13 +291,13 @@ return {
   },
 
   {
-    "nvim-lualine/lualine.nvim",
+    "nvim-lualine/lualine.nvim", -- status line along the bottom
     config = true,
-    opts = { options = { theme = "zenburn" } },
+    opts = { options = { theme = "zenburn" } }, -- this theme is supplied by the zenburn.nvim plugin
 
   },
   {
-    "akinsho/bufferline.nvim", config = true, lazy = false,
+    "akinsho/bufferline.nvim", config = true, lazy = false, -- tabs for buffers along the top
     keys = {
       {"<leader>b", "<cmd>BufferLinePick<CR>", desc = "Pick buffer"},
     },
@@ -323,9 +327,6 @@ return {
           separator = true,
           },
         },
-
-
-
       },
     },
 
@@ -434,11 +435,11 @@ return {
     end,
   },
   {
-    "williamboman/mason.nvim",
+    "williamboman/mason.nvim", -- convenient installation of LSP clients
     lazy = false, config = true,
   },
   {
-    "neovim/nvim-lspconfig",
+    "neovim/nvim-lspconfig", -- convenient configuration of LSP clients
 
     cmd = "LspStart",
 
@@ -499,7 +500,7 @@ return {
     },
   },
   {
-    "folke/trouble.nvim",
+    "folke/trouble.nvim", -- split window to show issues found by LSP
     dependencies = { "nvim-tree/nvim-web-devicons" },
     keys = {
       { "<leader>ct", "<cmd>TroubleToggle<CR>", desc = "Toggle trouble.nvim" },

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -434,7 +434,12 @@ return {
     end,
   },
   {
+    "williamboman/mason.nvim",
+    lazy = false, config = true,
+  },
+  {
     "neovim/nvim-lspconfig",
+
     cmd = "LspStart",
 
     init = function()

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -481,6 +481,7 @@ return {
           vim.keymap.set("n", "<leader>cK", vim.lsp.buf.hover, { buffer = ev.buf, desc = "Hover help" })
           vim.keymap.set("n", "<leader>crn", vim.lsp.buf.rename, { buffer = ev.buf, desc = "Rename" })
           vim.keymap.set("n", "<leader>cgr", vim.lsp.buf.references, { buffer = ev.buf, desc = "Goto references" })
+          vim.keymap.set("n", "<leader>ca", vim.lsp.buf.code_action, { buffer = ev.buf, desc = "Code action" })
         end,
       })
     end,

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -401,6 +401,72 @@ return {
       }
     end,
   },
+  {
+    "neovim/nvim-lspconfig",
+    cmd = "LspStart",
+
+    init = function()
+      local lspconfig = require("lspconfig")
+
+      -- Below, autostart = false means that you need to explicity call :LspStart (<leader>cl)
+      --
+      -- pyright is the language server for Python
+      lspconfig.pyright.setup({ autostart = false })
+
+      -- language server for R
+      lspconfig.r_language_server.setup({ autostart = false })
+
+      -- Language server for Lua. These are the recommended options
+      -- when mainly using Lua for Neovim
+      lspconfig.lua_ls.setup({
+        autostart = true,
+        on_init = function(client)
+          local path = client.workspace_folders[1].name
+          if not vim.loop.fs_stat(path .. "/.luarc.json") and not vim.loop.fs_stat(path .. "/.luarc.jsonc") then
+            client.config.settings = vim.tbl_deep_extend("force", client.config.settings, {
+              Lua = {
+                runtime = { version = "LuaJIT" },
+                workspace = {
+                  checkThirdParty = false,
+                  library = {
+                    vim.env.VIMRUNTIME,
+                  },
+                },
+              },
+            })
+
+            client.notify("workspace/didChangeConfiguration", { settings = client.config.settings })
+          end
+        end,
+      })
+
+      -- Use LspAttach autocommand to only map the following keys after
+      -- the language server attaches to the current buffer
+      vim.api.nvim_create_autocmd("LspAttach", {
+        group = vim.api.nvim_create_augroup("UserLspConfig", {}),
+        callback = function(ev)
+          vim.keymap.set("n", "<leader>cgd", vim.lsp.buf.definition, { buffer = ev.buf, desc = "Goto definition" })
+          vim.keymap.set("n", "<leader>cK", vim.lsp.buf.hover, { buffer = ev.buf, desc = "Hover help" })
+          vim.keymap.set("n", "<leader>crn", vim.lsp.buf.rename, { buffer = ev.buf, desc = "Rename" })
+          vim.keymap.set("n", "<leader>cgr", vim.lsp.buf.references, { buffer = ev.buf, desc = "Goto references" })
+        end,
+      })
+    end,
+    keys = {
+      -- Because autostart=false above, need to manually start the language server.
+      { "<leader>cl", "<cmd>LspStart<CR>", desc = "Start LSP" },
+      { "<leader>ce", vim.diagnostic.open_float, desc = "Open diagnostics/errors" },
+      { "]e", vim.diagnostic.goto_next, desc = "Next diagnostic/error" },
+      { "[e", vim.diagnostic.goto_prev, desc = "Prev diagnostic/error" },
+    },
+  },
+  {
+    "folke/trouble.nvim",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    keys = {
+      { "<leader>ct", "<cmd>TroubleToggle<CR>", desc = "Toggle trouble.nvim" },
+    },
+  },
 }
 
 -- vim: nowrap

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -22,7 +22,7 @@ return {
   { "sindrets/diffview.nvim", cmd = { "DiffviewOpen", "DiffviewFileHistory" } }, -- nice diff interface
   { "stsewd/sphinx.nvim", ft = "rst" }, -- syntax/grammar for Sphinx (ReST) documentation
   { "folke/which-key.nvim", lazy = false, config = true, }, -- pop up a window showing possible keybindings
-  { "phha/zenburn.nvim", lazy = false, priority = 1000 }, -- colorscheme
+  { "daler/zenburn.nvim", lazy = false, priority = 1000 }, -- colorscheme
   { "morhetz/gruvbox", enabled = false }, -- example of an alternative colorscheme, here disabled
   { "joshdick/onedark.vim", lazy = false }, -- another colorscheme, here enabled as a fallback for terminals with no true-color support like Terminal.app.
   {

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -287,16 +287,48 @@ return {
   },
 
   {
-    "vim-airline/vim-airline", -- status line along the bottom
-    dependencies = { "vim-airline/vim-airline-themes" },
-    init = function()
-      vim.cmd("let g:airline_theme='ayu_dark'") -- theme that looks good with zenburn
-      vim.cmd("let g:airline_powerline_fonts = 1") -- use powerline fonts; set to 0 if you don't have them installed
-      vim.cmd("let g:airline_extensions = ['tabline']") -- use the tabline extension
-      vim.cmd("let g:airline#extensions#tabline#enabled = 1")
-      vim.cmd("let g:airline#extensions#tabline#fnamemod = ':t'") -- just show the basename of the open file
-      -- vim.cmd("let g:airline#extensions#tabline#buffer_nr_show = 1") -- Show a buffer number for easier switching
-    end,
+    "nvim-lualine/lualine.nvim",
+    config = true,
+    opts = { options = { theme = "zenburn" } },
+
+  },
+  {
+    "akinsho/bufferline.nvim", config = true, lazy = false,
+    keys = {
+      {"<leader>b", "<cmd>BufferLinePick<CR>", desc = "Pick buffer"},
+    },
+    opts = {
+      options = {
+        right_mouse_command = "vertical sbufer %d",
+        separator_style = "slant",
+        hover = {
+          enabled = true, delay = 200, reveal = { "close" },
+        },
+        diagnostics = "nvim_lsp",
+        custom_filter = function(buf_number, buf_numbers)
+          if vim.bo[buf_number].filetype ~= "fugitive" then
+            return true
+        end
+        end,
+        show_buffer_icons = false,
+        offsets = {
+        {
+          filetype = "NvimTree",
+          highlight = "Directory",
+          separator = true,
+        },
+        {
+          filetype = "aerial",
+          highlight = "Directory",
+          separator = true,
+          },
+        },
+
+
+
+      },
+    },
+
   },
 
   {

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -43,8 +43,7 @@ return {
     lazy = false,
     config = true,
     keys = {
-      { "<leader>fbc", "<cmd>NvimTreeClose<CR>", desc = "[f]ile [b]rowser [c]lose (nvim-tree)" },
-      { "<leader>fbo", "<cmd>NvimTreeFocus<CR>", desc = "[f]ile [b]rowser [o]pen (or focus if open)" },
+      { "<leader>fb", "<cmd>NvimTreeToggle<CR>", desc = "[f]ile [b]rowser toggle" },
     },
   },
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -35,6 +35,10 @@ div.admonition {
     background-color: #f7f9ff;
 }
 
+div.seealso {
+    background-color: #fffaf1;
+}
+
 div.admonition p.admonition-title {
     font-size: 20px;
 }
@@ -57,4 +61,10 @@ kbd {
 
 kbd.compound {
     border: none;
+}
+
+.versionmodified {
+    border-left: 2px #5e6682 solid;
+    font-size: .8em;
+    padding: 5px;
 }

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,6 @@ Changelog
 - Disable tree-sitter indentation for Python and Snakemake; use the pep8 python indentation plugin instead.
 - Improve closing of buffers if they are not text buffers (aerial, nvim-tree, scratch from trouble.nvim)
 - Reintroduce gv.vim
-  need to run ``:LspStart`` or use the ``<leader>cl`` mapping.
 - Add trouble.nvim plugin
 - Add more hints to descriptions of keybindings
 - Instead of ``<leader>fbo`` and ``<leader>fbc`` to open and close the file

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,35 @@
 Changelog
 =========
 
+2023-10-29
+----------
+
+**vim/nvim**
+
+- Initial config for LSP (Python, R, Lua). Lua autostarts; for Python use
+  :kbd:`<leader>cl`. Use mason to install LSP servers. See :ref:`vim` for
+  details.
+- Use daler/zenburn.nvim fork for colorscheme; remove other zenburn colorscheme customizations
+- Disable tree-sitter indentation for Python and Snakemake; use the pep8 python indentation plugin instead.
+- Improve closing of buffers if they are not text buffers (aerial, nvim-tree, scratch from trouble.nvim)
+- Reintroduce gv.vim
+  need to run ``:LspStart`` or use the ``<leader>cl`` mapping.
+- Add trouble.nvim plugin
+- Add more hints to descriptions of keybindings
+- Instead of ``<leader>fbo`` and ``<leader>fbc`` to open and close the file
+  browser, just use ``<leader>fb`` to toggle it.
+- Replace vim-airline with lualine and bufferline
+- New plugins:
+  - nvim-lspconfig
+  - mason.nvim
+  - trouble.nvim
+  - bufferline
+  - lualine
+
+- Removed plugins:
+  - vim-airline
+
+
 2023-10-25
 ----------
 
@@ -41,6 +70,7 @@ keymapping documentation for details.
   - accelerated_jk
   - aerial
   - gitsigns
+  - diffview
 - modularize config into multiple lua files
 - convert mappings to have descriptions, so which-key picks them up
 - change how buffers are switched
@@ -49,7 +79,6 @@ keymapping documentation for details.
   - NERDTree (replaced by nvim-tree)
   - supertab (replaced by nvim-cmp)
   - simpylfold (replaced by treesitter folding)
-  - gv.vim (replaced by diffview and gitsigns)
 
 2023-09-19
 ----------

--- a/setup.sh
+++ b/setup.sh
@@ -253,6 +253,12 @@ function showHelp() {
         "to and provides a convenient interface for jumping directly" \
         "there." \
         "Homepage: https://github.com/ajeetdsouza/zoxide"
+    cmd "--install-pyright" \
+        "Python language server for nvim LSP."\
+        "Homepage: https://github.com/microsoft/pyright"
+    cmf "--install-lua-ls" \
+        "Lua language server for LSP."\
+        "Homepage: https://luals.github.io/#install"
     echo
 }
 
@@ -762,6 +768,36 @@ elif [ $task == "--install-bfg" ]; then
     chmod +x $BFG_WRAPPER
     check_opt_bin_in_path
     printf "${YELLOW}Installed jar file to ~/opt/bin, and created wrapper script ~/opt/bin/bfg.${UNSET}\n\n"
+
+elif [ $task == "--install-pyright" ]; then
+    ok "Install pyright to ~/opt/bin?"
+    eval "$(conda shell.bash hook)"
+    can_make_conda_env pyright
+    mamba create -y -n pyright pyright
+    for executable in pyright pyright-langserver pyright-python pyright-python-langserver; do
+        ln -sf "$CONDA_LOCATION/envs/pyright/bin/$executable" $HOME/opt/bin/$executable
+    done
+    printf "${YELLOW}Installed $HOME/opt/bin/pyright${UNSET}\n"
+
+elif [ $task == "--install-lua-ls" ]; then
+    ok "Install lua-ls?"
+    LUA_LS_VERSION=3.7.0
+    TAG="linux-x64"
+    if [[ $OSTYPE == darwin* ]]; then
+        TAG="darwin-x64"
+        if [[ $(uname -p) == arm ]]; then
+            TAG="darwin-arm64"
+        fi
+    fi
+    download https://github.com/LuaLS/lua-language-server/releases/download/${LUA_LS_VERSION}/lua-language-server-${LUA_LS_VERSION}-$TAG.tar.gz ~/opt/lua-ls.tar.gz
+    mkdir ~/opt/lua-ls
+    (
+        cd ~/opt/lua-ls
+        tar -xf ../lua-ls.tar.gz
+    )
+    echo "export PATH=$PATH:~/opt/lua-ls/bin" >> ~/.path
+    printf "${YELLOW}Created $HOME/opt/lua-ls and added its bin dir to the PATH in ~/.,path${UNSET}\n"
+
 
 elif [ $task == "--dotfiles" ]; then
     set -x

--- a/setup.sh
+++ b/setup.sh
@@ -253,12 +253,6 @@ function showHelp() {
         "to and provides a convenient interface for jumping directly" \
         "there." \
         "Homepage: https://github.com/ajeetdsouza/zoxide"
-    cmd "--install-pyright" \
-        "Python language server for nvim LSP."\
-        "Homepage: https://github.com/microsoft/pyright"
-    cmf "--install-lua-ls" \
-        "Lua language server for LSP."\
-        "Homepage: https://luals.github.io/#install"
     echo
 }
 
@@ -768,36 +762,6 @@ elif [ $task == "--install-bfg" ]; then
     chmod +x $BFG_WRAPPER
     check_opt_bin_in_path
     printf "${YELLOW}Installed jar file to ~/opt/bin, and created wrapper script ~/opt/bin/bfg.${UNSET}\n\n"
-
-elif [ $task == "--install-pyright" ]; then
-    ok "Install pyright to ~/opt/bin?"
-    eval "$(conda shell.bash hook)"
-    can_make_conda_env pyright
-    mamba create -y -n pyright pyright
-    for executable in pyright pyright-langserver pyright-python pyright-python-langserver; do
-        ln -sf "$CONDA_LOCATION/envs/pyright/bin/$executable" $HOME/opt/bin/$executable
-    done
-    printf "${YELLOW}Installed $HOME/opt/bin/pyright${UNSET}\n"
-
-elif [ $task == "--install-lua-ls" ]; then
-    ok "Install lua-ls?"
-    LUA_LS_VERSION=3.7.0
-    TAG="linux-x64"
-    if [[ $OSTYPE == darwin* ]]; then
-        TAG="darwin-x64"
-        if [[ $(uname -p) == arm ]]; then
-            TAG="darwin-arm64"
-        fi
-    fi
-    download https://github.com/LuaLS/lua-language-server/releases/download/${LUA_LS_VERSION}/lua-language-server-${LUA_LS_VERSION}-$TAG.tar.gz ~/opt/lua-ls.tar.gz
-    mkdir ~/opt/lua-ls
-    (
-        cd ~/opt/lua-ls
-        tar -xf ../lua-ls.tar.gz
-    )
-    echo "export PATH=$PATH:~/opt/lua-ls/bin" >> ~/.path
-    printf "${YELLOW}Created $HOME/opt/lua-ls and added its bin dir to the PATH in ~/.,path${UNSET}\n"
-
 
 elif [ $task == "--dotfiles" ]; then
     set -x


### PR DESCRIPTION
- Initial config for LSP (Python, R, Lua)
- Use daler/zenburn.nvim fork for colorscheme
- Disable tree-sitter indentation for Python and Snakemake; use the pep8 python indentation plugin instead.
- Improve closing of buffers if they are not text buffers (aerial, nvim-tree, scratch from trouble.nvim)
- Reintroduce gv.vim
- Add more hints to descriptions of keybindings
- just use ``<leader>fb`` to toggle nvim-tree browser.
- Replace vim-airline with lualine and bufferline
- New plugins:
  - nvim-lspconfig
  - mason.nvim
  - trouble.nvim
  - bufferline
  - lualine

- Removed plugins:
  - vim-airline