### PR TITLE
Doc updates

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -35,7 +35,7 @@ require("lazy").setup("plugins")
 -- Colorscheme.
 -- Add your favorite colorscheme to lua/plugins.lua, and use it here.
 --
-vim.cmd("colorscheme zenburn") -- bottom of this file has some tweaks to zenburn
+vim.cmd("colorscheme zenburn")
 
 -- Uncomment these lines if you use a terminal that does not support true color:
 -- vim.cmd("colorscheme onedark")

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -59,8 +59,6 @@ vim.cmd("set showmatch") -- Show matching parentheses
 vim.cmd("set nu") -- Show line numbers
 vim.cmd("set noshowmode") -- For use with vim-airline, which has its own
 vim.cmd("set mouse=a") -- Allow mouse usage.
-vim.cmd(":autocmd InsertEnter * set cul") -- Color the current line in upon entering insert mode
-vim.cmd(":autocmd InsertLeave * set nocul") -- Remove color upon existing insert mode
 vim.cmd(":autocmd InsertEnter * set listchars=tab:>•") -- Display nonprinting characters (tab characters and trailing spaces).
 vim.cmd(":autocmd InsertLeave * set listchars=tab:>•,trail:∙,nbsp:•,extends:⟩,precedes:⟨") -- also show trailing spaces after exiting insert mode
 vim.cmd("set formatoptions=qrn1coj") --  Changes the behavior of various formatting; see :h formatoptions.
@@ -74,7 +72,9 @@ vim.cmd("set wildmenu") -- Make tab completion for files/buffers act like bash
 vim.cmd("set wildmode=list:full") -- Show a list when pressing tab; complete first full match
 vim.cmd("set wildignore=*.swp,*.bak,*.pyc,*.class") -- Ignore these when autocompleting
 vim.cmd("set cursorline") -- Highlight line where the cursor is
-vim.cmd("set guicursor=i:block") -- Always use block cursor. In some terminals and fonts (like iTerm), it can be hard to see the cursor when it changes to a line.
+-- vim.cmd(":autocmd InsertEnter * set cul") -- Color the current line in upon entering insert mode
+-- vim.cmd(":autocmd InsertLeave * set nocul") -- Remove color upon existing insert mode
+-- vim.cmd("set guicursor=i:block") -- Always use block cursor. In some terminals and fonts (like iTerm), it can be hard to see the cursor when it changes to a line.
 
 --
 -- Keymappings
@@ -164,7 +164,6 @@ vim.api.nvim_create_autocmd("FileType", {
   pattern = "snakemake",
   callback = function() vim.cmd("set commentstring=#\\ %s") end,
 })
-
 
 -- Highlight yanked text
 vim.api.nvim_create_autocmd("TextYankPost", {

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -168,7 +168,7 @@ vim.api.nvim_create_autocmd("FileType", {
 -- Highlight yanked text
 vim.api.nvim_create_autocmd("TextYankPost", {
   callback = function()
-    vim.highlight.on_yank()
+    vim.highlight.on_yank{higroup = "IncSearch", timeout=100}
   end,
   pattern = "*",
 })

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -87,6 +87,10 @@ return {
   {
     "danilamihailov/beacon.nvim", -- flash a beacon to show where you are
     lazy = false, -- otherwise, on first KJ you get a double-flash
+    config = function ()
+      -- Disable the beacon globally; only the commands below will activate it.
+      vim.cmd("let g:beacon_enable=0")
+    end,
     keys = {
       { "<S-k><S-j>", ":Beacon<CR>", desc = "Flash beacon" },
       { "N", "N:Beacon<CR>", desc = "Prev search hit and flash beacon" },

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -125,7 +125,6 @@ return {
 
   {
     "akinsho/toggleterm.nvim", -- terminal in vim you can send code to
-    lazy = false,
     config = function()
       -- tweak the sizes of the new terminal
       require("toggleterm").setup({

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -42,7 +42,7 @@ return {
 
   {
     "nvim-tree/nvim-tree.lua", -- file browser
-    lazy = false,
+    lazy = true,
     config = true,
     keys = {
       { "<leader>fb", "<cmd>NvimTreeToggle<CR>", desc = "[f]ile [b]rowser toggle" },

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -184,7 +184,7 @@ return {
       require("nvim-treesitter.configs").setup({
         highlight = {
           enable = true,
-          disable = { "markdown", "rmarkdown" }, -- let pandoc handle highlighting for these
+          disable = { "rmarkdown" }, -- let pandoc handle highlighting for these
         },
         indent = {
           enable = true,

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,4 +132,4 @@ RUN echo "alias AGG=\"agg --font-family='FantasqueSansM Nerd Font'\"" >> ~/.alia
 # - EDIT: e.g. with Preview or ezgif
 # - 
 # - IMAGES:  mkdir imgs && convert -coalesce demo.gif imgs/%03d.gif
-ENTRYPOINT [ "/bin/bash" "-c" ]
+ENTRYPOINT [ "/bin/bash", "-c" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ ADD \
 .dircolors \
 .dircolors \
 .exports \
-.extra \
 .functions \
 .git-completion.bash \
 .gitconfig \

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,3 +132,4 @@ RUN echo "alias AGG=\"agg --font-family='FantasqueSansM Nerd Font'\"" >> ~/.alia
 # - EDIT: e.g. with Preview or ezgif
 # - 
 # - IMAGES:  mkdir imgs && convert -coalesce demo.gif imgs/%03d.gif
+ENTRYPOINT [ "/bin/bash" "-c" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
 FROM ubuntu:latest
 
-SHELL ["/bin/bash", "-c"]
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
+    curl \
+    git \
+    locales \
+    rsync \
+    sudo \
+    unzip \
+    vim \
+    wget
 
-RUN apt-get update && apt-get install -y git wget curl sudo rsync locales vim
-
-# Locale is set in .bash_profile; needs to be created
+# Locale is set in .bash_profile; needs to be created in this image though
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
 # From now on, use login shell so that bashrc gets sourced
+SHELL [ "/bin/bash", "-c" ]
 ENV SHELL /bin/bash
 
 # Get this installed up front out of the way without prompting for a region
@@ -79,12 +86,49 @@ RUN ./setup.sh --install-icdiff
 RUN ./setup.sh --install-jq
 RUN ./setup.sh --install-npm
 
+
 # Not working on --platform=linux/amd64
 # RUN ./setup.sh --install-radian
 
+
 # Additional for this container: asciinema for screen casts
 RUN source ~/.bashrc \
-    pip install asciinema \
-    conda install -n base r-base ipython
+    && ca \
+    && mamba create -y -n asciinema asciinema \
+    && ln -s $(mamba info --base)/envs/asciinema/bin/asciinema ~/opt/bin
 
-ENTRYPOINT ["/bin/bash", "-c"]
+# imagemagick for converting gifs
+RUN source ~/.bashrc \
+    && ca \
+    && mamba create -y -n imagemagick imagemagick \
+    && ln -s $(mamba info --base)/envs/imagemagick/bin/convert ~/opt/bin
+
+# Install fonts for use by agg
+RUN wget https://github.com/ryanoasis/nerd-fonts/releases/download/v3.0.2/FantasqueSansMono.zip \
+    && mkdir -p ~/.local/share/fonts \
+    && ( cd ~/.local/share/fonts \
+        && unzip /dotfiles/FantasqueSansMono.zip ) \
+    && fc-cache \
+    && rm /dotfiles/FantasqueSansMono.zip
+
+# asciinema/agg for cast -> gif
+RUN wget -O - https://github.com/asciinema/agg/releases/download/v1.4.3/agg-x86_64-unknown-linux-gnu > ~/opt/bin/agg \
+    && chmod +x ~/opt/bin/agg
+
+# make it easier to run by using a patched font
+RUN echo "alias AGG=\"agg --font-family='FantasqueSansM Nerd Font'\"" >> ~/.aliases
+
+# Allow lazy.nvim to update. Comment this out if you want to capture.
+# RUN nvim +"lua require('lazy').restore({wait=true})" +q
+
+# SCREENCAST WORKFLOW:
+#
+# tmux split-pane -h -l 100;  tmux split-pane -v -l 30
+# cd dotfiles/docs/gifs/working
+# docker run -v $PWD:/gifs --platform linux/amd64 --rm -it dotfiles
+#
+# - RECORD: asciinema rec demo.cast
+# - MAKE GIF: AGG /gifs/demo.cast /gifs/demo.gif
+# - EDIT: e.g. with Preview or ezgif
+# - 
+# - IMAGES:  mkdir imgs && convert -coalesce demo.gif imgs/%03d.gif

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -35,6 +35,10 @@ div.note {
     background-color: #f7f9ff;
 }
 
+div.tip {
+    background-color: #f1f8f1;
+}
+
 div.seealso {
     background-color: #fffaf1;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -31,7 +31,7 @@ summary {
     font-weight: bold;
 }
 
-div.admonition {
+div.note {
     background-color: #f7f9ff;
 }
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -67,8 +67,14 @@ kbd.compound {
     border: none;
 }
 
-.versionmodified {
+.versionadded {
+    border-left: 2px #da384c solid;
+    font-size: .8em;
+    padding-left: 5px;
+}
+
+.versionchanged {
     border-left: 2px #5e6682 solid;
     font-size: .8em;
-    padding: 5px;
+    padding-left: 5px;
 }

--- a/docs/bash.rst
+++ b/docs/bash.rst
@@ -6,25 +6,28 @@ Bash dotfiles
 ``.bashrc``
 -----------
 
+At the top of ``.bashrc``, the following files are sourced if they’re present.
+This keeps things a little more organized and modular:
+
+.. code-block:: bash
+
+  for file in ~/.{path,exports,bash_prompt,functions,aliases,extra}; do
+      [ -r "$file" ] && [ -f "$file" ] && source "$file";
+  done;
+  unset file;
+
+These files are described in the sections below, but a quick summary:
+
+- :ref:`.path`: all ``export PATH=...`` can go here.
+- :ref:`.aliases`: store your aliases here.
+- :ref:`.functions`: store your bash functions here.
+- :ref:`.bash_prompt`: edit your bash prompt here.
+- :ref:`.exports`: add your various env var exports here.
+- :ref:`.extra`: any machine-specific config goes here.
+
+
 The modular organization for bash configuration is inspired by `this
 repo <https://github.com/mathiasbynens/dotfiles>`__.
-
-``.bashrc`` sources the following files if they’re present. This keeps things
-a little more organized and modular. They work like this:
-
-::
-
-   .bash_profile  # sources .bashrc
-   .bashrc        # sources the following files:
-      --> .path         # all "export PATH=..." goes in here
-      --> .aliases      # add your aliases here
-      --> .functions    # add your functions here
-      --> .exports      # add your various exports here
-      --> .bash_prompt  # edit your bash prompt here
-      --> .extra        # any machine-specific config goes here
-
-Below is a little more detail on the contents of each of these files and
-some notable features.
 
 Other notable parts of the :file:`.bashrc`:
 
@@ -45,6 +48,8 @@ Other notable parts of the :file:`.bashrc`:
 
 ``.bash_profile`` does only one thing: it sources ``.bashrc``.
 
+.. _.path:
+
 ``.path``
 ---------
 
@@ -52,6 +57,8 @@ This file ends up being lots of ``export PATH="$PATH:/some/other/path"``
 lines. It is initially populated to put ``~/opt/bin`` and
 ``~/mambaforge/condabin`` on the path. As you install more software in other
 locations, this is a tidy place to put the various exports.
+
+.. _.aliases:
 
 ``.aliases``
 ------------
@@ -105,6 +112,8 @@ for the commands set for each alias.
       - Similar to above, but used for repos where ``main`` is the default
         branch instead of ``master``.
 
+.. _.functions:
+
 ``.functions``
 --------------
 
@@ -142,6 +151,9 @@ are set up. Some notable functions defined here:
         :file:`.ssh/config` file. Useful for when you're trying to remember how
         to log in to an infrequently-accessed host.
 
+
+.. _.bash_prompt:
+
 ``.bash_prompt``
 ----------------
 
@@ -150,11 +162,15 @@ here you can add any other hosts or colors. See
 https://misc.flogisoft.com/bash/tip_colors_and_formatting for color
 options.
 
+.. _.extra:
+
 ``.extra``
 ----------
 
 Nothing is in here by default. This is a good place to store host-specific
 details.
+
+.. _.exports:
 
 ``.exports``
 ------------

--- a/docs/bash.rst
+++ b/docs/bash.rst
@@ -3,6 +3,8 @@
 Bash dotfiles
 =============
 
+.. _bashrc:
+
 ``.bashrc``
 -----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,26 @@
 Changelog
 =========
 
+2023-11-07
+----------
+
+- Set up Dockerfile to create a screenshot-ready environment
+
+**vim/nvim**
+
+- Don't force the cursor to always be a block shape; add docs on how to get iTerm cursor looking nice
+- Always highlight the current line (rather than only in insert mode). Keeping
+  the previous lines in the config for future reference.
+- Lazily-load nvim-tree and toggleterm plugins
+- Allow treesitter to highlight markdown
+- Disable the beacon globally (on every click); now only activates on searches
+  or :kbd:`JK`.
+
+**docs**
+
+- Improvements to the docs based on recent feedback: iTerm cursor; zsh -> bash
+  up front; patched terminal font; warning about bioconda ARM.
+
 2023-11-01
 ----------
 

--- a/docs/details_ext.py
+++ b/docs/details_ext.py
@@ -91,7 +91,6 @@ def visit_details(self, node):
         self.body.append(
             f"<details><summary>{heading}</summary>"
             f'<div class="details">'
-            f"<p><i>{heading}</i></p>"
         )
 
 

--- a/docs/post.rst
+++ b/docs/post.rst
@@ -10,35 +10,58 @@ tasks.
 Mac
 ---
 
-- To turn off the iTerm2 audio bell (that "donk!" noise you get after hitting
-  TAB): under preferences, go to Profiles, then the Terminal tab. Make sure
-  "Silence bell" is checked.
+Cursor
+~~~~~~
 
-- To avoid the message abou zsh popping up all the time (and you still want to use bash):
+- In iTerm, I like tweaking the cursor a little, to have the block cursor show
+  inverted colors and to have the vertical line cursor a little wider so it's
+  easier to see. First, in Preference -> Profile -> Colors, select "Smart box
+  cursor color". Then in Preferences -> Advanced:
+
+    - width of vertical bar cursor: 2
+    - threshold for smart cursor for foreground: 0
+    - threshold for smart cursor for background: 0
+
+Disable bell
+~~~~~~~~~~~~
+
+To turn off the iTerm2 audio bell (that "donk!" noise you get after hitting
+TAB): under preferences, go to Profiles, then the Terminal tab. Make sure
+"Silence bell" is checked.
+
+.. _zshmac:
+
+zsh to bash
+~~~~~~~~~~~
+
+Recent macOS versions use ``zsh`` as the default shell instead of bash. These
+dotfiles assume bash as the default shell (for compatibility with HPC (Linux)
+systems which typically default to bash as well). See `this post
+<https://apple.stackexchange.com/a/361957>`_ for a great explanation of the
+differences. 
+
+The ``chsh`` command just has to be run once to change the shell to bash. To
+avoid the message about zsh popping up all the time (as `documented at
+support.apple.com <https://support.apple.com/en-us/HT208050>`_), set
+``BASH_SILENCE_DEPRECATION_WARNING=1``. Here, we export it in :file:`~/.extra`,
+which as :ref:`bashrc` describes, will be sourced by :file:`.bashrc` once these
+dotfiles are set up.
 
 .. code-block::
 
     chsh -s /bin/bash
+    echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.extra
 
-and then as `documented at support.apple.com
-<https://support.apple.com/en-us/HT208050>`_ export this env var to disable
-(e.g., in your `~/.extras` file):
+Touchbar
+~~~~~~~~
+To turn off the application-specific changing of the touch bar: System
+Preferences > Keyboard, then change "Touch Bar shows" to "Expanded Control
+Strip".
 
-.. code-block::
-
-    export BASH_SILENCE_DEPRECATION_WARNING=1
-
-- To turn off the application-specific changing of the touch bar: System
-  Preferences > Keyboard, then change "Touch Bar shows" to "Expanded Control
-  Strip".
-
-- In iTerm preferences:
-
-  - click the "General" icon, and check "Applications in terminal may access
-    clipboard"
-
-  - click the "Profiles" icon, and in the "Text" "Use built-in
-    Powerline glyphs"
+Copy/paste
+~~~~~~~~~~
+In iTerm preferences, click the "General" icon, and check "Applications in
+terminal may access clipboard"
 
 SSH config
 ----------

--- a/docs/starthere.rst
+++ b/docs/starthere.rst
@@ -18,7 +18,7 @@ A couple of preliminary things to get out of the way:
 
 .. details:: Details
 
-    For example: 
+    For example:
 
     * There are some common fixes for things like backspace in vim not working
       in tmux, spaces instead of tabs for Python code, getting the mouse to
@@ -40,9 +40,13 @@ A couple of preliminary things to get out of the way:
 ---------------------
 
 * Download the latest `zip file <https://github.com/daler/dotfiles/archive/master.zip>`_
-* Unzip it
-* Go to the unzipped directory
+* Unzip it and go to the unzipped directory in your terminal
 * Run ``./setup.sh`` to see the help.
+
+.. tip::
+
+   Are you setting up a recent Mac? The default shell is ``zsh`` which may cause
+   issues. See :ref:`zshmac` for how to change it back to bash.
 
 .. _dotfilessection:
 
@@ -65,6 +69,8 @@ files, and then close your terminal and reopen it to use the new configuration:
 
 .. code-block:: bash
 
+    # START FRESH....
+
     ./setup.sh --dotfiles
 
     # then close your terminal and re-open
@@ -86,10 +92,19 @@ files, and then close your terminal and reopen it to use the new configuration:
 
 Do this if you already have your own files.
 
-* Read through :ref:`bash`, :ref:`vim`, and :ref:`tmux` to see how things are set up here
-* Browse the dotfiles to look for parts that would be useful for you, and copy them into your own files
-* ``./setup.sh --vim-diffs`` may be helpful to you if you're updating
+* Read through :ref:`bash`, :ref:`vim`, and :ref:`tmux` to see how things are set up.
+* ``./setup.sh --vim-diffs`` may be helpful to you if you're updating. See
+  :ref:`working-with-diffs` if you need a refresher for working with diffs.
 * Use the tool installation commands as-is, but make sure :file:`~/opt/bin` is on your ``$PATH``
+
+.. code-block:: bash
+
+    # UPDATE EXISTING...
+
+    ./setup.sh --vim-diffs
+
+    # use standard vim diff operations, e.g.
+    # ]c, do, dp, :qa
 
 The remainder of this documentation will assume you're starting fresh.
 
@@ -100,20 +115,28 @@ The remainder of this documentation will assume you're starting fresh.
 2a: Set a patched terminal font
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Without a patched font, you'll get question mark symbols showing up in many places
-in nvim. That's because many of the plugins expect fonts with additional glyphs.
+* Manually download and install your favorite font from `nerdfonts.com
+  <https://www.nerdfonts.com/>`_. This needs to be done **on your local
+  machine**.
 
-Do this **on the machine running the terminal app.** This is almost always your
-local machine. For example, even if you're setting up dotfiles on a remote
-cluster, the font is installed on the laptop you're using to connect to that
-cluster.
+* Install by double-clicking the .ttf files. On Mac, for example, this will
+  open the font manager, where you can click the "Install" button.
 
-* Manually download and install your favorite font from `nerdfonts.com <https://www.nerdfonts.com/>`_.
-* Change your terminal program's preferences to use the new font. *Using
-  Terminal on Mac? You'll also need to set the font for non-ASCII characters.*
+* Change your terminal program's preferences to use the new font. You're
+  looking for a font that includes "Nerd Font". *Using Terminal on Mac? You'll
+  also need to set the same font for non-ASCII characters.*
 
 
 .. details:: Details
+
+  Without a patched font, you'll get question mark symbols showing up in many places
+  in nvim. That's because many of the plugins expect fonts with additional glyphs.
+
+  Do this **on the machine running the terminal app** because that's the program
+  displaying all the text. This is almost always your local machine. For example,
+  even if you're setting up dotfiles on a remote cluster, the font should not be
+  installed there. It should be installed on the laptop you're using to connect
+  to that cluster.
 
   In `this gif
   <https://raw.githubusercontent.com/wiki/vim-airline/vim-airline/screenshots/demo.gif>`_,
@@ -134,12 +157,18 @@ more help on deciding.
 
     ./setup.sh --install-neovim
 
+    # then close and reopen your terminal
+
 .. details:: Details
 
      This installs Neovim to :file:`~/opt/bin`, and then creates an ``alias
      vim=nvim`` in the :file:`~/.aliases` file (which is sourced by
      :file:`~/.bashrc`). This way, whenever you call ``vim``, the alias will
      redirect it to ``nvim``.
+
+     However it's important to close and reopen your terminal, because this
+     alias is conditional on finding nvim, and the alias is only created upon
+     first starting bash.
 
      If you want to use actual ``vim``, provide the full path when calling it.
      For example, on many machines it's at :file:`/usr/bin/vim`.
@@ -154,15 +183,17 @@ more help on deciding.
   changed. Please see :ref:`nvim-lua` for more context, rationale, and details
   on migrating to this new config method.
 
-Plugins are now managed via the `lazy.nvim
-<https://github.com/folke/lazy.nvim>`_ manager rather than ``vim-plug`` (as in
-previous versions of these dotfiles). Simply opening neovim should be
-sufficient to trigger ``lazy.nvim`` to download, install, and configure plugins
+Plugins are managed via the `lazy.nvim <https://github.com/folke/lazy.nvim>`_
+manager. Simply opening neovim should be sufficient to trigger ``lazy.nvim`` to
+bootstrap itself and then download, install, and configure plugins
 automatically.
+
+Or you can run this command to have it quit automatically when it's done:
 
 .. code-block:: bash
 
-  nvim
+  # this will open nvim, install plugins, and quit when done
+  nvim +"lua require('lazy').restore({wait=true})" +q
 
 .. details:: Details
 

--- a/docs/starthere.rst
+++ b/docs/starthere.rst
@@ -6,17 +6,19 @@ Start here
 
 A couple of preliminary things to get out of the way:
 
-* There are **three general sections**:
-   - :ref:`dotfilessection`
-   - :ref:`setupsection`
-   - :ref:`toolsection`
-
 * **Everything is driven by** :file:`setup.sh`. When in doubt, consult that
   file.
 
 * **Everything here is simply a convenience** to make life easier setting up
   a new machine. Since I spent the work figuring this out, I might as well make it
-  available to others. For example:
+  available to others.
+
+* **All steps are optional** though there are some dependencies and assumptions
+  which are noted as they come up.
+
+.. details:: Details
+
+    For example: 
 
     * There are some common fixes for things like backspace in vim not working
       in tmux, spaces instead of tabs for Python code, getting the mouse to
@@ -32,16 +34,15 @@ A couple of preliminary things to get out of the way:
     * A centrally available resource for setup and configuration means there's
       only one place to look for updates.
 
-* **All steps are optional** though there are some dependencies and assumptions
-  which are noted as they come up.
-
 .. _step0:
 
-Step 0: Download and check
---------------------------
+0: Download and check
+---------------------
 
 * Download the latest `zip file <https://github.com/daler/dotfiles/archive/master.zip>`_
-* Unzip, and go to the unzipped directory, and run ``./setup.sh`` to see the help.
+* Unzip it
+* Go to the unzipped directory
+* Run ``./setup.sh`` to see the help.
 
 .. _dotfilessection:
 
@@ -54,17 +55,19 @@ There are two paths to take here:
 
 .. rubric:: **Option 1: start fresh**
 
-Do this if you're setting up a new machine, or if you've made a backup of your
-files and want to try these out, or if you want the "batteries included"
-experience.
 
-To start fresh, do this to create or overwrite existing files, and then close
-your terminal and reopen it to use the new configuration:
+- Are you setting up a new machine?
+- Have you made a backup of your files and want to try these out?
+- Do you want the "batteries included" experience?
+
+Then you should probably start fresh. Do this to create or overwrite existing
+files, and then close your terminal and reopen it to use the new configuration:
 
 .. code-block:: bash
 
-    ./setup.sh --dotfiles   # then close your terminal and re-open
+    ./setup.sh --dotfiles
 
+    # then close your terminal and re-open
 
 .. details:: Details
     :anchor: dotfiles-details
@@ -94,41 +97,31 @@ The remainder of this documentation will assume you're starting fresh.
 
 2: Setup vim & conda
 --------------------
-2a: Set terminal font
-~~~~~~~~~~~~~~~~~~~~~
+2a: Set a patched terminal font
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In `this gif
-<https://raw.githubusercontent.com/wiki/vim-airline/vim-airline/screenshots/demo.gif>`_,
-you can see arrow shapes for buffers, line number glyphs, and so on. To get
-these, you need a patched font, and your terminal needs to be set to use the
-font.
+Without a patched font, you'll get question mark symbols showing up in many places
+in nvim. That's because many of the plugins expect fonts with additional glyphs.
 
-Skip this step if you don't want those.
+Do this **on the machine running the terminal app.** This is almost always your
+local machine. For example, even if you're setting up dotfiles on a remote
+cluster, the font is installed on the laptop you're using to connect to that
+cluster.
 
-This only needs to be done **on the machine you’re running the terminal app
-on.**  If you are setting up your dotfiles on a remote machine (say, on NIH's
-Biowulf) and your fonts look strange, you need to set install fonts on your
-*laptop* and set your terminal app (iTerm2, MobaXterm, Terminal.app, etc) to
-use that font.
+* Manually download and install your favorite font from `nerdfonts.com <https://www.nerdfonts.com/>`_.
+* Change your terminal program's preferences to use the new font. *Using
+  Terminal on Mac? You'll also need to set the font for non-ASCII characters.*
 
-There are several options for this:
 
-1. **If you are using ITerm2**, you can skip this step and instead click
-   a checkbox: Preferences -> Profiles -> Text -> Use built-in powerline
-   glyphs. You should see the symbols then. You will not get additional icons
-   for things like lazy.nvim
+.. details:: Details
 
-2. Manually download and install your favorite font from
-   https://www.nerdfonts.com/. Be sure to change your terminal program's
-   preferences to use the new font.
+  In `this gif
+  <https://raw.githubusercontent.com/wiki/vim-airline/vim-airline/screenshots/demo.gif>`_,
+  you can see arrow shapes for buffers, line number glyphs, and so on. To get
+  these, you need a patched font, and your terminal needs to be set to use the
+  font.
 
-Note that on Terminal on Mac, you'll also need to set the font for non-ASCII
-characters.
-
-.. note::
-
-   You may get a warning about "cannot load default config file". As long as
-   the new fonts show up, you should be fine.
+  Skip this step if you don't want those.
 
 
 2b: neovim
@@ -157,16 +150,15 @@ more help on deciding.
 
 .. note::
 
-  For long-time users of these dotfiles who may have older vim/nvim configs,
-  please see :ref:`nvim-lua` for more context, rationale, and details on
-  migrating to this new config method.
+  Have you used these dotfiles before? In Oct 2023, the nvim configuration
+  changed. Please see :ref:`nvim-lua` for more context, rationale, and details
+  on migrating to this new config method.
 
 Plugins are now managed via the `lazy.nvim
 <https://github.com/folke/lazy.nvim>`_ manager rather than ``vim-plug`` (as in
-previous versions of these dotfiles).
-
-Simply opening neovim should be sufficient to trigger ``lazy.nvim`` to
-download, install, and configure plugins automatically.
+previous versions of these dotfiles). Simply opening neovim should be
+sufficient to trigger ``lazy.nvim`` to download, install, and configure plugins
+automatically.
 
 .. code-block:: bash
 
@@ -203,6 +195,12 @@ details on how to activate environments.
 
   ./setup.sh --install-conda
   ./setup.sh --set-up-bioconda
+
+.. warning::
+
+    Are you on a Mac with an M1 or M2 chip? You will not be able to install
+    packages from Bioconda because packages are not built yet for the Apple
+    Silicon architecture.
 
 .. details:: Details
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -50,6 +50,9 @@ For Alacritty, see `this gist
 which also includes a setting you need in
 :file:`.config/alacritty/alacritty.yml`.
 
+On Mac, you can use ``./setup.sh --fix-tmux-terminfo`` and follow the
+instructions after running to update your tmux config.
+
 Can't install conda packages from Bioconda
 ------------------------------------------
 Bioconda does not yet build packages for Mac ARM chips (Mac M1 or M2). You can

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -36,7 +36,6 @@ which supports 256- and 16-color-only terminals:
    vim.cmd("set notermguicolors")
 
 
-
 Comments don't show up as italic
 --------------------------------
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,6 +1,11 @@
 Troubleshooting
 ===============
 
+Updating nvim plugins
+---------------------
+
+In nvim, run ``:Lazy``. In the interface, use ``U`` to update plugins.
+
 Vim has light gray text, colorscheme looks broken
 -------------------------------------------------
 

--- a/docs/vim.rst
+++ b/docs/vim.rst
@@ -51,6 +51,8 @@ of insert mode, so that every space typed doesn't show up as trailing. When
 wrap is off, the characters for "extends" and "precedes" indicate that there's
 text offscreen.
 
+.. _buffers:
+
 Switching buffers
 -----------------
 
@@ -843,6 +845,11 @@ a terminal-only version of git-cola or an alternative to tig. Specifically:
 
 The following commands are built-in vim commands when in diff mode, but
 are used heavily when working with ``:Gdiff``, so here is a reminder:
+
+.. _working-with-diffs:
+
+Working with diffs
+++++++++++++++++++
 
 .. list-table::
     :header-rows: 1

--- a/docs/vim.rst
+++ b/docs/vim.rst
@@ -301,6 +301,9 @@ toggle comments on lines or blocks of code.
 
 .. versionadded:: 2023-10-15
 
+.. versionchanged:: 2023-11-07
+   Only commands below will trigger the beacon
+
 `Beacon <https://github.com/danilamihailov/beacon.nvim>`_ provides an animated
 marker to show where the cursor is.
 

--- a/include.file
+++ b/include.file
@@ -8,7 +8,6 @@
 .config/nvim/lua/plugins.lua
 .dircolors
 .exports
-.extra
 .functions
 .git-completion.bash
 .gitconfig

--- a/setup.sh
+++ b/setup.sh
@@ -159,13 +159,6 @@ function showHelp() {
     cmd "--mac-stuff" \
         "Make some Mac-specific settings"
 
-    cmd "--powerline" \
-        "Install powerline fonts. Powerline fonts include the" \
-        "fancy glyphs used for the vim-airline status bar." \
-        "Only needs to be installed on local machine that is running" \
-        "the terminal app." \
-        "Homepage: https://github.com/vim-airline/vim-airline"
-
     cmd "--fix-tmux-terminfo" \
         "Update terminfo so that italics work within tmux; " \
         "see https://jdhao.github.io/2018/10/19/tmux_nvim_true_color"
@@ -530,16 +523,6 @@ elif [ $task == "--mac-stuff" ]; then
     ok "Sets the shell to be bash, and silences the warning about zsh being the default by adding an env var to ~/.extra"
     chsh -s /bin/bash
     echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.extra
-
-elif [ $task == "--powerline" ]; then
-    ok "Installs patched powerline fonts from https://github.com/powerline/fonts for use with vim-airline"
-    git clone https://github.com/powerline/fonts.git --depth 1 /tmp/fonts
-    (cd /tmp/fonts && ./install.sh)
-    rm -rf /tmp/fonts
-    echo
-    printf "${YELLOW}Change your terminal's config to use the new powerline patched fonts${UNSET}\n"
-    echo
-
 
 
 # ----------------------------------------------------------------------------

--- a/setup.sh
+++ b/setup.sh
@@ -799,9 +799,9 @@ elif [ $task == "--fix-tmux-terminfo" ]; then
     ok "Runs the fix from https://jdhao.github.io/2018/10/19/tmux_nvim_true_color/ for getting italics in tmux"
     download http://invisible-island.net/datafiles/current/terminfo.src.gz terminfo.src.gz
     gunzip terminfo.src.gz
-    tic -xe tmux-256color terminfo.src
+    tic -xe tmux-256color,screen-256color terminfo.src
     rm terminfo.src
-    printf "${YELLOW}Added ~/.terminfo. You can now use 'set -g default-terminal \"screen-256color\" in your .tmux.conf.${UNSET}\n"
+    printf "${YELLOW}Added ~/.terminfo. You can now use 'set -g default-terminal \"tmux-256color\" in your .tmux.conf.${UNSET}\n"
 
 
 


### PR DESCRIPTION
- Update the docs based on some recent feedback
- Includes removing the setup command for installing powerline fonts, notes on iterm cursor, switching to bash from zsh up front, warning about bioconda ARM
- lazy-load toggleterm and nvim-tree plugins
- don't force cursor to block shape
- disable beacon globally