### PR TITLE
Rmarkdown tweaks

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -72,8 +72,8 @@ vim.cmd("set wildmenu") -- Make tab completion for files/buffers act like bash
 vim.cmd("set wildmode=list:full") -- Show a list when pressing tab; complete first full match
 vim.cmd("set wildignore=*.swp,*.bak,*.pyc,*.class") -- Ignore these when autocompleting
 vim.cmd("set cursorline") -- Highlight line where the cursor is
-vim.cmd(":autocmd InsertEnter * set cul") -- Color the current line in upon entering insert mode
-vim.cmd(":autocmd InsertLeave * set nocul") -- Remove color upon existing insert mode
+-- vim.cmd(":autocmd InsertEnter * set cul") -- Color the current line in upon entering insert mode
+-- vim.cmd(":autocmd InsertLeave * set nocul") -- Remove color upon existing insert mode
 -- vim.cmd("set guicursor=i:block") -- Always use block cursor. In some terminals and fonts (like iTerm), it can be hard to see the cursor when it changes to a line.
 
 --

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -168,6 +168,20 @@ vim.api.nvim_create_autocmd("FileType", {
 -- Even though treesitter is configured to not highlight rmarkdown,
 -- highlighting still shows up about about half the time. This enforces
 -- highlights to be disabled in rmarkdown buffers.
+
+-- Render RMarkdown in R running in terminal
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = { "rmarkdown", "rmd" },
+  callback = function()
+    vim.keymap.set(
+      "n",
+      "<leader>k",
+      ":TermExec cmd='rmarkdown::render(\"%:p\")'<CR>",
+      { desc = "Render RMar[k]down to HTML" }
+    )
+  end,
+})
+
 vim.api.nvim_create_autocmd("FileType", {
   pattern = "rmarkdown",
   callback = function()

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -137,7 +137,7 @@ vim.api.nvim_create_autocmd("Filetype", {
 })
 
 vim.api.nvim_create_autocmd("Filetype", {
-  pattern = "markdown",
+  pattern = { "markdown", "rmd" },
   callback = function()
     vim.keymap.set(
       { "n", "i" },

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -117,6 +117,8 @@ vim.keymap.set("t", "<leader>q", "<C-\\><C-n>:wincmd h<CR>", { desc = "Move to l
 
 vim.fn.setreg("l", "I'A',j") -- "listify": wrap with quotes and add trailing comma
 
+vim.cmd("hi @text.literal.block.markdown gui=NONE") -- Turn of the default italic italics on fenced code blocks in markdown/rmarkdown
+
 -- Autocommands.
 -- Autocommands are triggered by an action, like opening a particular filetype.
 
@@ -165,9 +167,6 @@ vim.api.nvim_create_autocmd("FileType", {
   callback = function() vim.cmd("set commentstring=#\\ %s") end,
 })
 
--- Even though treesitter is configured to not highlight rmarkdown,
--- highlighting still shows up about about half the time. This enforces
--- highlights to be disabled in rmarkdown buffers.
 
 -- Render RMarkdown in R running in terminal
 vim.api.nvim_create_autocmd("FileType", {
@@ -182,11 +181,11 @@ vim.api.nvim_create_autocmd("FileType", {
   end,
 })
 
+-- Run Python code in IPython running in terminal
 vim.api.nvim_create_autocmd("FileType", {
-  pattern = "rmarkdown",
+  pattern = "python",
   callback = function()
-    require("nvim-treesitter")
-    vim.cmd("TSDisable highlight rmarkdown")
+    vim.keymap.set("n", "<leader>k", ":TermExec cmd='run %:p'<CR>", { desc = "Run Python file in IPython" })
   end,
 })
 

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -91,7 +91,7 @@ vim.keymap.set("t", "<Esc>", "<C-\\><C-n>") -- Fix <Esc> in terminal buffer
 vim.keymap.set("n", "<Leader>H", ":set hlsearch!<CR>", { desc = "Toggle search highlight" })
 vim.keymap.set("n", "<leader>W", ":%s/\\s\\+$//<cr>:let @/=''<CR>", { desc = "Clean trailing whitespace" })
 vim.keymap.set({ "n", "i" }, "<leader>R", "<Esc>:syntax sync fromstart<CR>", { desc = "Refresh syntax highlighting" })
-vim.keymap.set({ "n", "i" }, "<leader>`", "i```{r}<CR>```<Esc>O", { desc = "New fenced RMarkdown code block" })
+vim.keymap.set({ "n", "i" }, "<leader>`", "<Esc>i```{r}<CR>```<Esc>O", { desc = "New fenced RMarkdown code block" })
 vim.keymap.set(
   { "n", "i" },
   "<leader>ts",

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -72,8 +72,8 @@ vim.cmd("set wildmenu") -- Make tab completion for files/buffers act like bash
 vim.cmd("set wildmode=list:full") -- Show a list when pressing tab; complete first full match
 vim.cmd("set wildignore=*.swp,*.bak,*.pyc,*.class") -- Ignore these when autocompleting
 vim.cmd("set cursorline") -- Highlight line where the cursor is
--- vim.cmd(":autocmd InsertEnter * set cul") -- Color the current line in upon entering insert mode
--- vim.cmd(":autocmd InsertLeave * set nocul") -- Remove color upon existing insert mode
+vim.cmd(":autocmd InsertEnter * set cul") -- Color the current line in upon entering insert mode
+vim.cmd(":autocmd InsertLeave * set nocul") -- Remove color upon existing insert mode
 -- vim.cmd("set guicursor=i:block") -- Always use block cursor. In some terminals and fonts (like iTerm), it can be hard to see the cursor when it changes to a line.
 
 --

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -125,7 +125,7 @@ return {
     end,
     keys = {
       { "gxx", ":ToggleTermSendCurrentLine<CR><CR>", desc = "Send current line to terminal" },
-      { "gx", ":ToggleTermSendVisualSelection<CR><CR>", desc = "Send selection to terminal", mode = "x" },
+      { "gx", ":ToggleTermSendVisualSelection<CR>'><CR>", desc = "Send selection to terminal", mode = "x" },
       {
         "<leader>cd",
         "/```{r<CR>NjV/```<CR>k<Esc>:ToggleTermSendVisualSelection<CR>/```{r<CR>",

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -147,7 +147,6 @@ return {
       require("nvim-treesitter.configs").setup({
         highlight = {
           enable = true,
-          disable = { "rmarkdown" }, -- let pandoc handle highlighting for these
         },
         indent = {
           enable = true,

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -50,18 +50,6 @@ return {
   },
 
   {
-    "vim-pandoc/vim-pandoc-syntax", -- improves editing markdown and ReST
-    ft = { "markdown", "rmarkdown" },
-    dependencies = { "vim-pandoc/vim-pandoc" },
-  },
-
-  {
-    "vim-pandoc/vim-rmarkdown", -- improves editing RMarkdown
-    ft = "rmarkdown",
-    dependencies = { "vim-pandoc/vim-pandoc-syntax", "vim-pandoc/vim-pandoc" },
-  },
-
-  {
     "nvim-telescope/telescope.nvim", -- pop-up window used for fuzzy-searching and selecting
     dependencies = {
       "nvim-lua/plenary.nvim",
@@ -109,17 +97,6 @@ return {
     config = function()
       -- see :help accelerated_jk_acceleration_table
       vim.cmd("let g:accelerated_jk_acceleration_table = [7, 13, 20, 33, 53, 86]")
-    end,
-  },
-
-  {
-    "vim-pandoc/vim-pandoc", -- improves editing markdown and RMarkdown
-    lazy = true,
-    init = function()
-      vim.cmd("let g:pandoc#syntax#conceal#use = 0") -- " Disable the conversion of ``` to lambda and other fancy concealment/conversion that ends up confusing me
-      vim.cmd("let g:pandoc#folding#fold_fenced_codeblocks = 1") -- " RMarkdown code blocks can be folded too
-      vim.cmd("let g:pandoc#spell#enabled = 0") -- " By default, keep spell-check off. Turn on with `set spell`
-      vim.cmd("let g:pandoc#keyboard#display_motions = 0") -- Disable remapping j to gj and k to gk
     end,
   },
 

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -42,7 +42,7 @@ return {
 
   {
     "nvim-tree/nvim-tree.lua", -- file browser
-    lazy = true,
+    lazy = false, -- otherwise, opening a directory as first buffer doesn't trigger it.
     config = true,
     keys = {
       { "<leader>fb", "<cmd>NvimTreeToggle<CR>", desc = "[f]ile [b]rowser toggle" },

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -145,26 +145,6 @@ return {
         end,
       })
 
-      -- Only set this for RMarkdown
-      vim.api.nvim_create_autocmd("FileType", {
-        pattern = "rmarkdown",
-        callback = function()
-          vim.keymap.set(
-            "n",
-            "<leader>k",
-            ":TermExec cmd='rmarkdown::render(\"%:p\")'<CR>",
-            { desc = "Render RMar[k]down to HTML" }
-          )
-        end,
-      })
-
-      -- Only set this for Python
-      vim.api.nvim_create_autocmd("FileType", {
-        pattern = "python",
-        callback = function()
-          vim.keymap.set("n", "<leader>k", ":TermExec cmd='run %:p'<CR>", { desc = "Run Python file in IPython" })
-        end,
-      })
     end,
     keys = {
       { "gxx", ":ToggleTermSendCurrentLine<CR><CR>", desc = "Send current line to terminal" },

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+2023-11-14
+----------
+
+**vim/nvim**
+
+Tweaks for working with RMarkdown documents.
+
+- Decided to remove the vim-pandoc family of plugins; it seems they were
+  conflicting with treesitter highlighting. Treesitter is going a good job of
+  it, and correctly allows :kbd:`gcc` commenting within R code chunks. Various
+  filetypes set to use ``rmd`` rather than ``rmarkdown``.
+- Renable lazy-load of nvim-tree, so that opening a directory works properly.
+- :kbd:`gxx` to send lines to terminal now jumps to the bottom of the selection once sent.
+- By default, treesitter's highlighting of markdown fenced code blocks (e.g.,
+  RMarkdown chunks) makes everything italic. Disable this in
+  :file:`.config/nvim/init.lua`.
+
+
 2023-11-08
 ----------
 - Turn off cursorline in a terminal buffer

--- a/docs/vim.rst
+++ b/docs/vim.rst
@@ -993,7 +993,7 @@ The following algorithms are available:
 
 .. versionadded:: 2019-03-27
 
-`vim-table-mode <https://github.com/vim-pandoc/vim-pandoc-syntax>`_ provides
+`vim-table-mode <https://github.com/dhruvasagar/vim-table-mode>`_ provides
 easy formatting of tables in Markdown and Restructured Text
 
 Nice Markdown tables are a pain to format. This plugin makes it easy, by
@@ -1189,36 +1189,51 @@ No additional commands configured.
 
 .. versionadded:: 2019-02-27
 
-`vim-rmarkdown <https://github.com/vim-pandoc/vim-rmarkdown>`_ provides syntax
-highlighting for R within RMarkdown code chunks. Requires both ``vim-pandoc``
-and ``vim-pandoc-syntax``, described below.
+.. deprecated:: 2023-11-14
+  Removed in favor of treesitter
 
-No additional commands configured.
+.. details:: Deprecation notes
+
+  `vim-rmarkdown <https://github.com/vim-pandoc/vim-rmarkdown>`_ provides syntax
+  highlighting for R within RMarkdown code chunks. Requires both ``vim-pandoc``
+  and ``vim-pandoc-syntax``, described below.
+
+  No additional commands configured.
 
 ``vim-pandoc``
 ~~~~~~~~~~~~~~
 
 .. versionadded:: 2019-02-27
 
-`vim-pandoc <https://github.com/vim-pandoc/vim-pandoc>`_ Integration with
-`pandoc <http://johnmacfarlane.net/pandoc/>`_. Uses vim-pandoc-syntax (see
-below) for syntax highlighting.
+.. deprecated:: 2023-11-14
+   Removed in favor of treesitter
 
-Includes folding and formatting. Lots of shortcuts are defined by this plugin,
-see ``:help vim-pandoc`` for much more.
+.. details:: Deprecation notes
 
-No additional commands configured.
+  `vim-pandoc <https://github.com/vim-pandoc/vim-pandoc>`_ Integration with
+  `pandoc <http://johnmacfarlane.net/pandoc/>`_. Uses vim-pandoc-syntax (see
+  below) for syntax highlighting.
+
+  Includes folding and formatting. Lots of shortcuts are defined by this plugin,
+  see ``:help vim-pandoc`` for much more.
+
+  No additional commands configured.
 
 ``vim-pandoc-syntax``
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2019-02-27
 
-`vim-pandoc-syntax <https://github.com/vim-pandoc/vim-pandoc-syntax>`_ is used
-by vim-pandoc (above). It is a separate plugin because the authors found it
-easier to track bugs separately.
+.. deprecated:: 2023-11-14
+  Removed in favor of treesitter
 
-No additional commands configured.
+.. details:: Deprecation notes
+
+  `vim-pandoc-syntax <https://github.com/vim-pandoc/vim-pandoc-syntax>`_ is used
+  by vim-pandoc (above). It is a separate plugin because the authors found it
+  easier to track bugs separately.
+
+  No additional commands configured.
 
 
 ``vim-tmux-clipboard``
@@ -1257,3 +1272,45 @@ This uses my fork of https://github.com/phha/zenburn.nvim, which adds addtional
 support for plugins and tweaks some of the existing colors to work better.
 
 No additional commands configured.
+
+Colorschemes
+------------
+
+For years I've been using the venerable *zenburn* colorscheme. However, now
+with additional plugins and highlighting mechansims (especially treesitter), it
+became important to be able to configure more than what was available in the 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/vim.rst
+++ b/docs/vim.rst
@@ -1278,39 +1278,11 @@ Colorschemes
 
 For years I've been using the venerable *zenburn* colorscheme. However, now
 with additional plugins and highlighting mechansims (especially treesitter), it
-became important to be able to configure more than what was available in the 
+became important to be able to configure more than what that colorscheme supported.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+The `zenburn.nvim <https://github.com/phha/zenburn.nvim>`_ repo was a reboot of
+this colorscheme, but there were some parts of it that I wanted to change, or
+at least have more control over. Hence `my fork of the repo
+<https://github.com/daler/zenburn.nvim>`_, which is used here. If you're
+interested in tweaking your own colorschemes, I've hopefully documented that
+fork enough to give you an idea of how to modify on your own.


### PR DESCRIPTION
- removed the vim-pandoc family of plugins as they had a lot of extra functionality I didn't need, and they seemed to be conflicting with treesitter (even when treesitter was apparently disabled). Treesitter works quite well with the ability to comment out with `gcc` within RMarkdown chunks, so I didn't see a need for vim-pandoc et al plugins any more.
- this needed a setting in init.lua to disable the italics within rmarkdown code chunks
- there was also a confusion between rmarkdown and rmd file types; treesitter expects rmd
- when sending a selection to terminal with `gxx`, go to the bottom of the selection.