### PR TITLE
ReStructured Text and treesitter troubleshooting

### DIFF
--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -151,6 +151,7 @@ return {
           enable = true,
           disable = { "python", "snakemake" }, -- let vim-python-pep8-indent handle this
         },
+        -- These will be attempted to be installed automatically, but you'll need a C compiler installed.
         ensure_installed = {
           "bash",
           "css",

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -21,7 +21,6 @@ return {
   { "tpope/vim-fugitive", cmd = "Git", lazy = true }, -- convenient git interface, with incremental commits
   { "junegunn/gv.vim", cmd = "GV", dependencies = {"tpope/vim-fugitive"}, lazy = true}, -- graphical git log
   { "sindrets/diffview.nvim", cmd = { "DiffviewOpen", "DiffviewFileHistory" } }, -- nice diff interface
-  { "stsewd/sphinx.nvim", ft = "rst" }, -- syntax/grammar for Sphinx (ReST) documentation
   { "folke/which-key.nvim", lazy = false, config = true, }, -- pop up a window showing possible keybindings
   { "daler/zenburn.nvim", lazy = false, priority = 1000 }, -- colorscheme
   { "morhetz/gruvbox", enabled = false }, -- example of an alternative colorscheme, here disabled
@@ -165,7 +164,6 @@ return {
           "vim",
           "yaml",
           "r",
-          "rst",
           "snakemake",
         },
         incremental_selection = {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+2023-12-31
+----------
+
+**setup.sh**
+
+Changed the recommended order of events, and added a note to open vim to let it install plugins.
+
+**docs**
+
+Added troubleshooting notes for treesitter if there's no compiler available on the system
+
+**vim/nvim**
+
+Remove ReStructured Text treesitter parser and sphinx plugin, since they do not
+yet support `ReST substitutions
+<https://docutils.sourceforge.io/docs/ref/rst/directives.html#directives-for-substitution-definitions>`__.
+
 2023-11-14
 ----------
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -69,3 +69,20 @@ Can't install conda packages from Bioconda
 Bioconda does not yet build packages for Mac ARM chips (Mac M1 or M2). You can
 install docker and use a container, or wait until Bioconda starts building
 those packages.
+
+
+Errors about not finding CC or GCC when opening vim
+---------------------------------------------------
+
+You may get an error like this when opening nvim:
+
+::
+
+   Error detected while processing BufReadPost Autocommands for "*":
+   No C compiler found! "cc", "gcc", "clang", "cl", "zig" are not executable.
+   No C compiler found! "cc", "gcc", "clang", "cl", "zig" are not executable.
+   ....
+
+This happens because nvim is trying to install the treesitter parsers, but that
+needs a compiler to be available. See :ref:`treesitter` for details on how to
+address this.

--- a/docs/vim.rst
+++ b/docs/vim.rst
@@ -534,6 +534,9 @@ For navigating complex codebases, there are other keys that are automatically
 mapped, which you can read about in the `README for aerial
 <https://github.com/stevearc/aerial.nvim>`_.
 
+
+.. _treesitter:
+
 ``treesitter``
 ~~~~~~~~~~~~~~
 
@@ -545,6 +548,23 @@ are functions, classes, variables, modules, etc. Then it's up to other plugins
 to do something with that. For example, colorschemes can use that information,
 or you can select text based on its semantic meaning within the programming
 language.
+
+In :file:`~/.config/lua/plugins.lua`, treesitter is configured to ensure the
+listed parsers are installed. These will be attempted to be installed
+automatically, but they do require a C compiler to be installed.
+
+
+- On a Mac, this may need XCode Command Line Tools to be installed.
+- A fresh Ubuntu installation will need ``sudo apt install build-essential``
+- RHEL/Fedora will need ``sudo dnf install 'Development Tools'`` (and may need
+  the `EPEL repo <https://docs.fedoraproject.org/en-US/epel/>`__ enabled).
+- Alternatively, if you don't have root access, you can install `compiler
+  packages via conda
+  <https://docs.conda.io/projects/conda-build/en/stable/resources/compiler-tools.html>`_, 
+
+Alternatively, comment out the entire ``ensure_installed`` block in
+:file:`~/.config/lua/plugins.lua`; this means you will not have
+treesitter-enabled syntax highlighting though.
 
 
 .. list-table::

--- a/setup.sh
+++ b/setup.sh
@@ -92,10 +92,11 @@ function showHelp() {
 
     header "RECOMMENDED ORDER:"
     echo "    1)  ./setup.sh --dotfiles"
-    echo "    2)  CLOSE TERMINAL, OPEN A NEW ONE"
-    echo "    3)  ./setup.sh --install-neovim"
-    echo "    5)  ./setup.sh --install-conda"
-    echo "    6)  ./setup.sh --set-up-bioconda"
+    echo "    2)  ./setup.sh --install-neovim"
+    echo "    3)  ./setup.sh --install-conda"
+    echo "    4)  ./setup.sh --set-up-bioconda"
+    echo "    5) CLOSE TERMINAL, OPEN A NEW ONE"
+    echo "    6) Open vim (which should now be aliased to nvim) and allow plugins to install, then quit"
     echo "    7)  ./setup.sh --install-fzf"
     echo "    8)  ./setup.sh --install-ripgrep"
     echo "    9)  ./setup.sh --install-vd"
@@ -457,7 +458,7 @@ elif [ $task == "--install-conda" ]; then
     bash mambaforge.sh -b -p $MAMBAFORGE_DIR
     rm mambaforge.sh
     echo "export PATH=\$PATH:$MAMBAFORGE_DIR/condabin" >> ~/.path
-    printf "${YELLOW}conda installed at ${MAMBAFORGE_DIR}/condabin. This has been added to your ~/.path file, but you should double-check to make sure it gets on your path.${UNSET}\n"
+    printf "${YELLOW}conda installed at ${MAMBAFORGE_DIR}/condabin. This has been added to your ~/.path file, but you should double-check to make sure it gets on your path. You may need to close and then reopen your terminal.${UNSET}\n"
 
 elif [ $task == "--set-up-bioconda" ]; then
     ok "Sets up Bioconda by adding the dependent channels in the correct order"

--- a/tests/test_commands
+++ b/tests/test_commands
@@ -2,3 +2,6 @@ pyp 1+8	9
 which mamba	/root/dockeruser/mambaforge/condabin/mamba
 black --version | head -n1	black, 22.6.0 (compiled: no)
 vd --version	saul.pw/VisiData v2.11
+rg --version | grep ripgrep	ripgrep 13.0.0 (rev af6b6c543b)
+fd --version	fd 8.5.3
+fzf -q run --select-1	run-tests.sh

--- a/tests/test_commands
+++ b/tests/test_commands
@@ -4,4 +4,4 @@ black --version | head -n1	black, 22.6.0 (compiled: no)
 vd --version	saul.pw/VisiData v2.11
 rg --version | grep ripgrep	ripgrep 13.0.0 (rev af6b6c543b)
 fd --version	fd 8.5.3
-fzf -q run --select-1	run-tests.sh
+fzf --version	0.44.1 (d7d2ac3)


### PR DESCRIPTION
Turns out the treesitter ReStructured Text parser doesn't support [ReST substitutions](https://docutils.sourceforge.io/docs/ref/rst/directives.html#directives-for-substitution-definitions), and using them in a document causes nvim to hang. So this disables their use (which unfortunately prevents `aerial` from being used on ReST files).

This also adds some troubleshooting notes about compilers and treesitter parsers.

It also tries to streamline the installation process by rearranging when to restart the terminal in the recommended steps.