### PR TITLE
Update .bashrc and .functions for macos ls behavior.

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -28,6 +28,7 @@ fi
 if [ `command -v dircolors` ]; then
     test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
 fi
+update_mac_ls_colors
 
 if [[ $OSTYPE == darwin* ]]; then
     test -f ~/.git-completion.bash && source ~/.git-completion.bash

--- a/.functions
+++ b/.functions
@@ -34,6 +34,7 @@ function tre() {
 
 # Select a conda env to activate
 sa() {
+    ca    # otherwise: -bash: activate: No such file or directory
     local name=$(conda env list | grep -v "#" | fzf)
     local env=$(echo $name | awk '{print $1}');
     eval "source activate $env";
@@ -78,6 +79,27 @@ function prsetup {
     echo "  git push $contributor HEAD:$contributor_branch"
 }
 
+function update_mac_ls_colors() {
+    # This function checks if 1) OS is MacOS, 2) coreutils installed in conda's base
+    # environment, 3) conda installed to path specified in '.setup.sh'. If so,
+    # resets ls/dircolors for more consistent behavior across environments.
+    if [[ $OSTYPE == darwin* ]]; then
+        MAMBAFORGE_DIR=$HOME/mambaforge
+        if [ -d "$MAMBAFORGE_DIR" ]; then
+            # reset ls alias (from .aliases)
+            file="$MAMBAFORGE_DIR/bin/ls"
+            if [ -r "$file" ] && [ -f "$file" ]; then
+                alias ls="$file --color=auto"
+            fi
+            # re-evaluate dircolors and re-export LS_COLORS (from .bashrc)
+            file="$MAMBAFORGE_DIR/bin/dircolors"
+            if [ -r "$file" ] && [ -f "$file" ]; then
+                test -r ~/.dircolors && eval "$($file -b ~/.dircolors)" || eval "$($file -b)"
+            fi
+        fi
+    fi
+}
+
 function ca() {
     # This function allows you to activate the base env only when you're ready
     # to (and don't activate it on EVERY new shell).
@@ -85,6 +107,7 @@ function ca() {
     # You can also provide an env name or path to activate it.
     eval "$(conda shell.bash hook 2> /dev/null)"
     conda activate "$@"
+    update_mac_ls_colors
 }
 
 

--- a/.path
+++ b/.path
@@ -1,1 +1,1 @@
-export PATH=$PATH:$HOME/opt/bin
+export PATH=$HOME/opt/bin:$PATH


### PR DESCRIPTION
See issue #33 

Added update_mac_ls_colors() to .functions and .bashrc to sync/reset ls and dircolor colors on macos, when coreutils is installed in conda base environment.

Tested platforms:
- macos sonomoa 14.2.1, terminal (iterm2 not tested)
- ubuntu 12.04.06 LTS based image

Follow .setup.sh RECOMMENDED ORDER with minimal changes:
```
    1)  ./setup.sh --dotfiles
    2)  ./setup.sh --install-neovim
    3)  ./setup.sh --install-conda
    4)  ./setup.sh --set-up-bioconda
    5) CLOSE TERMINAL, OPEN A NEW ONE
    Optional:
       conda config --set ssl_verify /asbolute/path/to/CA.crt
    6) Open vim (which should now be aliased to nvim) and allow plugins to install, then quit
    7)  ./setup.sh --install-fzf
    8)  ./setup.sh --install-ripgrep
    9)  ./setup.sh --install-vd
    10) ./setup.sh --install-pyp
    11) ./setup.sh --install-fd

  On Mac:
       ./setup.sh --mac-stuff
       # ./setup.sh --install-tmux    # skip
       conda install --file requirements-mac.txt  # skip ./setup.sh --conda-env
```

DO NOT add conda auto-initialize (e.g. 'conda init bash') - handled by ca(), sa() and conda_deactivate_all()


old ls behavior on mac (not tested on linux):
```
la    # no conda activated, ls -G colors
ca fd
la    # ls -G colors
conda_deactivate_all
la    # ls -G colors
ca
la    # no term colors
conda activate $HOME/mambaforge/envs/pyp
la    # ls -G colors
ca
la    # no term colors; which ls: $HOME/mambaforge/bin/ls
source ~/.bashrc
la    # alias ls='ls --color=auto'; which ls: $HOME/mambaforge/bin/ls
```


new ls behavior on mac and linux:
```
la    # no conda activated, alias ls='ls --color=auto'
ca fd
la    # alias ls='ls --color=auto'
conda_deactivate_all
la    # alias ls='ls --color=auto'
ca
la    # alias ls='ls --color=auto'
conda activate $HOME/mambaforge/envs/pyp
la    # alias ls='ls --color=auto'
ca
la    # alias ls='ls --color=auto'
source ~/.bashrc    # not needed, adding for consistency
la    # alias ls='ls --color=auto'; which ls: $HOME/mambaforge/bin/ls
```
