### PR TITLE
Update .path and setup.sh --conda-env for macos ls

### DIFF
--- a/.functions
+++ b/.functions
@@ -34,6 +34,7 @@ function tre() {
 
 # Select a conda env to activate
 sa() {
+    ca    # avoid '-bash: activate: No such file or directory'
     local name=$(conda env list | grep -v "#" | fzf)
     local env=$(echo $name | awk '{print $1}');
     eval "source activate $env";

--- a/.path
+++ b/.path
@@ -1,1 +1,1 @@
-export PATH=$PATH:$HOME/opt/bin
+export PATH=$HOME/opt/bin:$PATH

--- a/setup.sh
+++ b/setup.sh
@@ -473,6 +473,24 @@ elif [ $task == "--conda-env" ]; then
     if [[ $OSTYPE == darwin* ]]; then
         ok "Installs dependencies in 'requirements.txt' and 'requirements-mac.txt' into the base conda environment"
         conda install --file requirements.txt --file requirements-mac.txt
+
+        MAMBAFORGE_DIR=$HOME/mambaforge
+        if [[ $HOSTNAME == "helix.nih.gov" || $HOSTNAME == "biowulf.nih.gov" ]]; then
+            MAMBAFORGE_DIR=/data/$USER/mambaforge
+        fi
+        file="$MAMBAFORGE_DIR/bin/ls"
+        if [ -r "$file" ] && [ -f "$file" ]; then
+            ln -sf $file $HOME/opt/bin/ls
+            printf "${YELLOW}- found coreutils ls in $MAMBAFORGE_DIR/bin${UNSET}\n"
+            printf "${YELLOW}- created symlink $HOME/opt/bin/ls${UNSET}\n"
+        fi
+        file="$MAMBAFORGE_DIR/bin/dircolors"
+        if [ -r "$file" ] && [ -f "$file" ]; then
+            ln -sf $file $HOME/opt/bin/dircolors
+            printf "${YELLOW}- found coreutils dircolors in $MAMBAFORGE_DIR/bin${UNSET}\n"
+            printf "${YELLOW}- created symlink $HOME/opt/bin/dircolors${UNSET}\n"
+        fi
+        check_opt_bin_in_path
     else
         ok "Installs dependencies in 'requirements.txt' into the base conda environment"
         conda install --file requirements.txt


### PR DESCRIPTION
See #33. On macos with coreutils installed into base conda environment, minor changes to files to improve ls color consistency.
- Prepend "~/opt/bin" to path to prioritize user specified functionality. Otherwise /bin/ls may be used over coreutils ls
- Add symlinks for conda installed coreutils ls and dircolors to ~/opt/bin to make accessible outside base env

Tested conditions:
- macos sonomoa 14.2.1
- ubuntu 18.04.06 LTS based image
- DO NOT add conda auto-initialize (e.g. 'conda init bash'), let ca() and conda_deactivate_all() handle this.

Follow .setup.sh RECOMMENDED ORDER with minimal changes:
```
    1)  ./setup.sh --dotfiles
    2)  ./setup.sh --install-neovim
    3)  ./setup.sh --install-conda
    4)  ./setup.sh --set-up-bioconda
    5) CLOSE TERMINAL, OPEN A NEW ONE
    Optional:
       conda config --set ssl_verify /asbolute/path/to/CA.crt
    6) Open vim (which should now be aliased to nvim) and allow plugins to install, then quit
    7)  ./setup.sh --install-fzf
    8)  ./setup.sh --install-ripgrep
    9)  ./setup.sh --install-vd
    10) ./setup.sh --install-pyp
    11) ./setup.sh --install-fd

  On Mac:
       ./setup.sh --mac-stuff
       # ./setup.sh --install-tmux    # skip
       ./setup.sh --conda-env    # requirements.txt empty for testing
  On Linux:
       ./setup.sh --conda-env    # requirements.txt empty for testing
```


old ls behavior on mac (not tested on linux):
```
la    # no conda activated, ls -G colors
ca fd
la    # ls -G colors
conda_deactivate_all
la    # ls -G colors
ca
la    # no term colors
conda activate $HOME/mambaforge/envs/pyp
la    # ls -G colors
ca
la    # no term colors
source ~/.bashrc
la    # alias ls='ls --color=auto'
```


new ls behavior on mac and linux:
```
la    # no conda activated, alias ls='ls --color=auto'
ca fd
la    # alias ls='ls --color=auto'
conda_deactivate_all
la    # alias ls='ls --color=auto'
ca
la    # alias ls='ls --color=auto'
conda activate $HOME/mambaforge/envs/pyp
la    # alias ls='ls --color=auto'
ca
la    # alias ls='ls --color=auto'
source ~/.bashrc    # not needed, adding for consistency
la    # alias ls='ls --color=auto'; which ls: $HOME/mambaforge/bin/ls
sa    # visidata
```
