### PR TITLE
make ls more consistent on Mac; fixes #33

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -49,8 +49,7 @@ alias grep='grep --color=auto'
 alias D="export DISPLAY=:0"
 
 # View syntax-highlighted files in the current directory, live-filtered by fzf.
-alias v='fzf --preview "bat --color \"always\" {}"'
-
+alias v='fzf --preview "bat --color \"always\" --theme GitHub {}"'
 
 # Save three keystrokes to go up a directory
 alias ..="cd .."

--- a/.aliases
+++ b/.aliases
@@ -1,23 +1,48 @@
 #!/usr/bin/env bash
 
-alias grep='grep --color=auto'
-alias ls='ls --color=auto'
+# Set the alias to nvim *only* if we can find nvim on the path.
+# If this is not behaving as expected, try closing and reopening your terminal.
+if command -v nvim > /dev/null; then
+    alias vim=nvim
+fi
 
-# Vanilla MacOS has a different `ls` for which we use -G instead of --color.
-# However if you've conda-installed coreutils, that `ls` will be used.
+
+# Some notes on `ls` on Mac...
 #
-# So the following sets the color differently if we're on Mac and not using
-# coreutils from conda.
+# Vanilla MacOS, based on BSD, has a different `ls`. It uses -G instead
+# of --color. The colors are also handled differently (dircolors is not
+# available by default; uses different env vars for controlling colors).
+#
+# Previously depended on a conda environment with GNU coreutils
+# installed so that we get the exact same colors as on Linux. That proved
+# finicky. See [0] for some details.  so this always uses the system `ls` on Mac, setting the colors to be
+# close enough.
+#
+# The solution here is:
+#  - check $LS_COLORS (note underscore) in an environment with dircolors and GNU ls
+#  - paste the value of $LS_COLORS into [2]
+#  - copy the reported $LSCOLORS (no underscore) value. That will be used by BSD ls.
+#  - export LSCOLORS on Mac.
+#
+# [0] https://github.com/daler/dotfiles/pull/35
+# [1] https://superuser.com/a/1746907
+# [2] https://geoff.greer.fm/lscolors
+#
 if [[ $OSTYPE == darwin* ]]; then
-    if [[ `which ls` == "/usr/bin/ls" ]] || [[ `which ls` == "/bin/ls" ]]; then
-        alias ls='ls -G'
+    export LSCOLORS=ExGxBxDxCxEgEdxbxgxcxd
+    alias ls='/bin/ls -G'
+else
+    if command -v dircolors > /dev/null; then
+        test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
     fi
+    alias ls="ls --color=auto"
 fi
 
 alias ll='ls -lrth'
 alias la='ls -lrthA'
 alias l='ls -CF'
 alias tmux="tmux -u"
+alias grep='grep --color=auto'
 
 # Sometimes when you try to open an X window, especially running tmux, you can
 # get an error about the display variable not being set. This alias fixes that.

--- a/.aliases
+++ b/.aliases
@@ -53,8 +53,6 @@ alias v='fzf --preview "bat --color \"always\" --theme GitHub {}"'
 
 # Save three keystrokes to go up a directory
 alias ..="cd .."
-alias git-clean-branches-master="git branch --merged master | grep -v \"\* master\" | xargs -n 1 git branch -d"
-alias git-clean-branches-main="git branch --merged main | grep -v \"\* main\" | xargs -n 1 git branch -d"
 
 # Run git-fugitive.
 # Great for incrementally making git commits in the current directory. I don't

--- a/.aliases
+++ b/.aliases
@@ -52,10 +52,20 @@ alias D="export DISPLAY=:0"
 alias v='fzf --preview "bat --color \"always\" {}"'
 
 
+# Save three keystrokes to go up a directory
 alias ..="cd .."
 alias git-clean-branches-master="git branch --merged master | grep -v \"\* master\" | xargs -n 1 git branch -d"
 alias git-clean-branches-main="git branch --merged main | grep -v \"\* main\" | xargs -n 1 git branch -d"
 
+# Run git-fugitive.
+# Great for incrementally making git commits in the current directory. I don't
+# remember the original mnemonic for "gsv", but it's muscle memory for me
+# now...but the more logical "fugitive" does the same thing.
 alias gsv="vim -c ':Git' -c ':bunload 1'"
+alias fugitive="vim -c ':Git' -c ':bunload 1'"
+
+# Run diffview.nvim to see the log. Mnemonic is "git log, visual"
 alias glv="vim -c ':DiffviewFileHistory'"
+
+# Start the SSH agent, prompting for your passphrase.
 alias s="start_agent"

--- a/.aliases
+++ b/.aliases
@@ -51,9 +51,6 @@ alias D="export DISPLAY=:0"
 # View syntax-highlighted files in the current directory, live-filtered by fzf.
 alias v='fzf --preview "bat --color \"always\" {}"'
 
-if command -v nvim > /dev/null; then
-    alias vim=nvim
-fi
 
 alias ..="cd .."
 alias git-clean-branches-master="git branch --merged master | grep -v \"\* master\" | xargs -n 1 git branch -d"

--- a/.bashrc
+++ b/.bashrc
@@ -24,11 +24,6 @@ fi
 # makes less work on things like tarballs and images
 [ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
 
-# enable color support of ls and also add handy aliases
-if [ `command -v dircolors` ]; then
-    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
-fi
-
 if [[ $OSTYPE == darwin* ]]; then
     test -f ~/.git-completion.bash && source ~/.git-completion.bash
 fi

--- a/.functions
+++ b/.functions
@@ -108,3 +108,16 @@ function hostlist() {
         | column -t \
         | sort
 }
+
+function git-clean-branches () {
+    # Print local branches that have been merged into main (or master).
+    #
+    # Auto-detect whether to use main/master.
+    local DEFAULT_BRANCH=$(git branch | grep -Ew "main|master" | sed "s/\* //")
+
+    # Just print the names. If you're on a branch that has been merged (has
+    # a "*"), don't print it
+    git branch --merged $DEFAULT_BRANCH | grep -v "\*" | grep -Evw $DEFAULT_BRANCH
+
+    echo "Use 'git-clean-branches | xargs git branch -d' to actually delete these." >&2
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,13 +95,13 @@ RUN ./setup.sh --install-npm
 RUN source ~/.bashrc \
     && ca \
     && mamba create -y -n asciinema asciinema \
-    && ln -s $(mamba info --base)/envs/asciinema/bin/asciinema ~/opt/bin
+    && ln -s $(conda info --base)/envs/asciinema/bin/asciinema ~/opt/bin
 
 # imagemagick for converting gifs
 RUN source ~/.bashrc \
     && ca \
     && mamba create -y -n imagemagick imagemagick \
-    && ln -s $(mamba info --base)/envs/imagemagick/bin/convert ~/opt/bin
+    && ln -s $(conda info --base)/envs/imagemagick/bin/convert ~/opt/bin
 
 # Install fonts for use by agg
 RUN wget https://github.com/ryanoasis/nerd-fonts/releases/download/v3.0.2/FantasqueSansMono.zip \

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+2023-01-21
+----------
+
+**bash**
+
+Make ``ls`` more consistent on Mac.
+
+Previously, there was sometimes inconsistent behavior depending on the state of
+conda environments (see `#35 <https://github.com/daler/dotfiles/pull/35>`__ for
+some details).
+
+This change means that additional coloring of files by extension (like
+compressed files and images) is not available on Mac. But directories,
+executables, and symlinks will always be shown with color and using the
+built-in ``/bin/ls``, so the end result will be more consistent behavior.
+
 2023-12-31
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,13 @@ compressed files and images) is not available on Mac. But directories,
 executables, and symlinks will always be shown with color and using the
 built-in ``/bin/ls``, so the end result will be more consistent behavior.
 
+This also removes the ``git-clean-branches-main`` and
+``git-clean-branches-master`` aliases, which could break in some circumstances.
+In order to make it a bit safer to use, these have been replaced with
+a ``git-clean-branches`` function that only prints the branches. If those look
+good, then it can be run again, piping to ``xargs git branch -d``.
+
+
 2023-12-31
 ----------
 

--- a/setup.sh
+++ b/setup.sh
@@ -328,7 +328,10 @@ check_for_conda () {
     if command -v conda > /dev/null; then
 
         CONDA_LOCATION=$(conda info --base)
-        MAMBA_LOCATION=$(mamba info --base)
+
+        # In 1.5.5, mamba info --base now alwo reports version. So only grab
+        # the line that has a path on it.
+        MAMBA_LOCATION=$(mamba info --base | grep "/")
 
         # Even if the user has not run conda init, this will enable the use of
         # "conda activate" within the various conda creation steps below.

--- a/tests/test_commands
+++ b/tests/test_commands
@@ -4,4 +4,4 @@ black --version | head -n1	black, 22.6.0 (compiled: no)
 vd --version	saul.pw/VisiData v2.11
 rg --version | grep ripgrep	ripgrep 13.0.0 (rev af6b6c543b)
 fd --version	fd 8.5.3
-fzf --version	0.44.1 (d7d2ac3)
+fzf --version	0.45.0 (202401011)


### PR DESCRIPTION
This makes `ls` on Mac more consistent, avoiding depending on any conda envs with GNU `ls` installed.

The downside is that additional coloring of known filetypes (compressed files, images, etc) is not possible on default Mac as it is on Linux with `dircolors`, but we gain consistency in the color of directories, executables, and symlinks.

xrefs:
- #33
- #34
- #35

Ping @rhodesch.

This also adds some other fixes:

- add comments in aliases
- replace buggy-in-some-situations `git-clean-branches-main` and `git-clean-branches-master` aliases with a new `git-clean-branches` function that only prints the branches it wants to delete.
