### PR TITLE
Mac keyboard fix

### DIFF
--- a/DefaultKeyBinding.dict
+++ b/DefaultKeyBinding.dict
@@ -1,0 +1,52 @@
+/*
+When using an external, non-Mac keyboard, the modified keybindings below make
+the Home/End keys always jump to the beginning/end of a LINE rather than the
+DOCUMENT.
+
+This file should be placed in ~/Library/KeyBindings/DefaultKeyBinding.dict, and
+programs need to be restarted to pick up the new behavior.
+
+REFERENCES:
+- https://gist.github.com/trusktr/1e5e516df4e8032cbc3d
+- https://www.reddit.com/r/MacOS/comments/pz9vnu/comment/iqn3acw/
+
+Key Modifiers
+^ : Ctrl
+$ : Shift
+~ : Option (Alt)
+@ : Command (Apple)
+# : Numeric Keypad
+
+Non-Printable Key Codes
+
+Standard
+Up Arrow:     \UF700        Backspace:    \U0008        F1:           \UF704
+Down Arrow:   \UF701        Tab:          \U0009        F2:           \UF705
+Left Arrow:   \UF702        Escape:       \U001B        F3:           \UF706
+Right Arrow:  \UF703        Enter:        \U000A        ...
+Insert:       \UF727        Page Up:      \UF72C
+Delete:       \UF728        Page Down:    \UF72D
+Home:         \UF729        Print Screen: \UF72E
+End:          \UF72B        Scroll Lock:  \UF72F
+Break:        \UF732        Pause:        \UF730
+SysReq:       \UF731        Menu:         \UF735
+Help:         \UF746
+
+OS X
+delete:       \U007F
+
+*/
+
+
+{
+
+"\UF729" = "moveToBeginningOfLine:";
+"\UF72B" = "moveToEndOfLine:";
+"$\UF729" = moveToBeginningOfLineAndModifySelection:; // shift-home
+"$\UF72B" = moveToEndOfLineAndModifySelection:; // shift-end
+"^\UF729" = moveToBeginningOfDocument:; // ctrl-home
+"^\UF72B" = moveToEndOfDocument:; // ctrl-end
+"^$\UF729" = moveToBeginningOfDocumentAndModifySelection:; // ctrl-shift-home
+"^$\UF72B" = moveToEndOfDocumentAndModifySelection:; // ctrl-shift-end
+
+}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,13 @@ In order to make it a bit safer to use, these have been replaced with
 a ``git-clean-branches`` function that only prints the branches. If those look
 good, then it can be run again, piping to ``xargs git branch -d``.
 
+**setup.sh**
+
+New argument, ``--mac-keyboard-fix``. This makes Home/End keys on an external,
+non-Mac keyboard behave like they do on Windows and Linux. This makes the keys
+jump to the beginning/end of a *line* rather than beginning/end of
+a *document*. This is most noticeable in large text input boxes in a web
+browser.
 
 2023-12-31
 ----------

--- a/docs/post.rst
+++ b/docs/post.rst
@@ -29,6 +29,24 @@ To turn off the iTerm2 audio bell (that "donk!" noise you get after hitting
 TAB): under preferences, go to Profiles, then the Terminal tab. Make sure
 "Silence bell" is checked.
 
+
+Fix keyboard on Mac
+~~~~~~~~~~~~~~~~~~~
+
+By default on Mac, unless overridden by a program, Home and End jump to the
+beginning/end of a *document* rather than a *line*. This is different from the
+Windows and Linux behavior of jumping to beginning/end of a line.
+
+The typical workaround is to use Cmd-Left and Cmd-Right. Some programs (like
+Outlook on Mac) already override this. But some don't, noticeable web browsers.
+When editing a large text input box in a web browser, it can be frustrating if
+you mistakenly hit End, expecting to jump to the end of a like in Outlook, but
+instead it jumps to the very end of the text input and you have to go find where you were.
+
+Running ``./setup.sh --mac-keyboard-fix`` fixes this by creating a new
+``~/Library/KeyBindings/DefaultKeyBinding.dict`` file; see that file for
+details. You'll need to restart programs to see the effect.
+
 .. _zshmac:
 
 zsh to bash
@@ -51,6 +69,8 @@ dotfiles are set up.
 
     chsh -s /bin/bash
     echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.extra
+
+This can also be done by using ``./setup.sh --mac-stuff``.
 
 Touchbar
 ~~~~~~~~

--- a/setup.sh
+++ b/setup.sh
@@ -160,6 +160,9 @@ function showHelp() {
     cmd "--mac-stuff" \
         "Make some Mac-specific settings"
 
+    cmd "--mac-keyboard-fix" \
+        "Fix Home/End behavior when using an external, non-Mac keyboard"
+
     cmd "--fix-tmux-terminfo" \
         "Update terminfo so that italics work within tmux; " \
         "see https://jdhao.github.io/2018/10/19/tmux_nvim_true_color"
@@ -525,6 +528,12 @@ elif [ $task == "--mac-stuff" ]; then
     chsh -s /bin/bash
     echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.extra
 
+
+elif [ $task == "--mac-keyboard-fix" ]; then
+    ok "Fix Home/End key behavior when using an external, non-Mac keyboard."
+    mkdir -p ~/Library/KeyBindings
+    cp DefaultKeyBinding.dict ~/Library/KeyBindings/DefaultKeyBinding.dict
+    printf "${YELLOW}Created ~/Library/KeyBindings/DefaultKeyBinding.dict; restart programs to see the effect.${UNSET}\n"
 
 # ----------------------------------------------------------------------------
 # Individual --install commands

--- a/setup.sh
+++ b/setup.sh
@@ -331,7 +331,10 @@ check_for_conda () {
     if command -v conda > /dev/null; then
 
         CONDA_LOCATION=$(conda info --base)
-        MAMBA_LOCATION=$(mamba info --base)
+
+        # In 1.5.5, mamba info --base now alwo reports version. So only grab
+        # the line that has a path on it.
+        MAMBA_LOCATION=$(mamba info --base | grep "/")
 
         # Even if the user has not run conda init, this will enable the use of
         # "conda activate" within the various conda creation steps below.

--- a/tests/test_commands
+++ b/tests/test_commands
@@ -4,4 +4,4 @@ black --version | head -n1	black, 22.6.0 (compiled: no)
 vd --version	saul.pw/VisiData v2.11
 rg --version | grep ripgrep	ripgrep 13.0.0 (rev af6b6c543b)
 fd --version	fd 8.5.3
-fzf --version	0.44.1 (d7d2ac3)
+fzf --version	0.45.0 (202401011)


### PR DESCRIPTION
Fixes home/end behavior on Mac when using an external non-Mac keyboard. This adds a new `setup.sh --mac-keyboard-fix` argument; see changes in this PR for more details.

(ping @aliciaaevans)