### PR TITLE
markdown and ReST link formatting

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -133,6 +133,12 @@ vim.api.nvim_create_autocmd("Filetype", {
       '<Esc>:r! date "+\\%Y-\\%m-\\%d"<CR>A<CR>----------<CR>',
       { desc = "Insert date as section title" }
     )
+    vim.keymap.set(
+      "n",
+      "<leader>p",
+      'i` <>`__<Esc>F<"+pF`a',
+      { desc = "Paste a ReST-formatted link from system clipboard" }
+    )
   end,
 })
 
@@ -144,6 +150,13 @@ vim.api.nvim_create_autocmd("Filetype", {
       "<leader>d",
       '<Esc>:r! date "+\\# \\%Y-\\%m-\\%d"<CR>A',
       { desc = "Insert date as section title" }
+    )
+
+    vim.keymap.set(
+      "n",
+      "<leader>p",
+      'i[]()<Esc>h"+pF]i',
+      { desc = "Paste a Markdown-formatted link from system clipboard" }
     )
   end,
 })

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,12 @@ jump to the beginning/end of a *line* rather than beginning/end of
 a *document*. This is most noticeable in large text input boxes in a web
 browser.
 
+**vim/nvim**
+
+New :kbd:`<leader>p` command for pasting the contents of the OS clipboard into
+a formatted Markdown or ReST-formatted link, and place the cursor in insert
+mode in the link description.
+
 2023-12-31
 ----------
 

--- a/docs/vim.rst
+++ b/docs/vim.rst
@@ -221,7 +221,9 @@ which-key will provide a description for it.
     * - :kbd:`<leader>p`
       - Paste the contents of the OS clipboard into a formatted link as
         appropriate for the file type (ReST and Markdown currently supported)
-        and puts the cursor in the link description.
+        and puts the cursor in the link description. Note that this will *not*
+        work to paste to vim on a remote server, unless you do tricky things
+        with X forwarding, so consider it local-only.
 
 .. _plugins:
 

--- a/docs/vim.rst
+++ b/docs/vim.rst
@@ -218,6 +218,11 @@ which-key will provide a description for it.
       - Insert the current date as a ReST or Markdown-formatted title,
         depending on the file type. Useful when writing logs.
 
+    * - :kbd:`<leader>p`
+      - Paste the contents of the OS clipboard into a formatted link as
+        appropriate for the file type (ReST and Markdown currently supported)
+        and puts the cursor in the link description.
+
 .. _plugins:
 
 Plugins


### PR DESCRIPTION
When pasting from the OS clipboard (i.e. after copying a url from a browser), use `<leader>p` to paste the link into markdown or ReStructured Text, creating the correct syntax for the filetype, and putting the cursor in insert mode at the point where the description should go.

Currently this only works when editing *locally*; otherwise to access the clipboard on a remote machine and in tmux takes a lot of contorted X-forwarding work. Will need to think more about how best to handle that.