### PR TITLE
nvim updates, 2024-03-31

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -106,6 +106,7 @@ vim.keymap.set("n", "[b", ":bprevious<CR>", { desc = "Previous buffer" })
 vim.keymap.set("n", "]b", ":bnext<CR>", { desc = "Next buffer" })
 vim.keymap.set("n", "H", ":bprevious<CR>", { desc = "Previous buffer" })
 vim.keymap.set("n", "L", ":bnext<CR>", { desc = "Next buffer" })
+vim.keymap.set("n", "<leader>cp", ":IBLToggle<CR>:set nu!<CR>", { desc = "Prepare for copying text to another program"}) 
 
 -- Keymappings for navigating terminals.
 -- <leader>q and <leader>w move to left and right windows respectively. Useful

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -188,12 +188,7 @@ return {
     end,
   },
 
-  {
-    "ggandor/leap.nvim", -- quickly jump around the buffer without counting lines
-    config = function()
-      require("leap").set_default_keymaps()
-    end,
-  },
+  
 
   {
     "lukas-reineke/indent-blankline.nvim", -- show vertical lines at tabstops
@@ -515,6 +510,17 @@ return {
       end,
     },
   },
-}
 
+  {
+    "folke/flash.nvim", -- search and select, including with treesitter
+    event = "VeryLazy",
+    opts = {},
+    keys = {
+      { "s", mode = { "n", "x", "o" }, function() require("flash").jump() end, desc = "Flash" },
+      { "S", mode = { "n", "x", "o" }, function() require("flash").treesitter() end, desc = "Flash Treesitter" },
+      { "<c-s>", mode = { "c" }, function() require("flash").toggle() end, desc = "Toggle Flash Search" },
+    },
+  },
+
+}
 -- vim: nowrap

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -467,8 +467,8 @@ return {
       -- Because autostart=false above, need to manually start the language server.
       { "<leader>cl", "<cmd>LspStart<CR>", desc = "Start LSP" },
       { "<leader>ce", vim.diagnostic.open_float, desc = "Open diagnostics/errors" },
-      { "]e", vim.diagnostic.goto_next, desc = "Next diagnostic/error" },
-      { "[e", vim.diagnostic.goto_prev, desc = "Prev diagnostic/error" },
+      { "]d", vim.diagnostic.goto_next, desc = "Next diagnostic/error" },
+      { "[d", vim.diagnostic.goto_prev, desc = "Prev diagnostic/error" },
     },
   },
   {

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -421,6 +421,8 @@ return {
       -- pyright is the language server for Python
       lspconfig.pyright.setup({ autostart = false })
 
+      lspconfig.bashls.setup({ autostart = false })
+
       -- language server for R
       lspconfig.r_language_server.setup({ autostart = false })
 

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -478,6 +478,43 @@ return {
       { "<leader>ct", "<cmd>TroubleToggle<CR>", desc = "Toggle trouble.nvim" },
     },
   },
+
+  {
+    "stevearc/conform.nvim", -- run code through formatter
+    event = { "BufWritePre" },
+    cmd = { "ConformInfo" },
+    keys = {
+      {
+        "<leader>cf",
+        function()
+          require("conform").format({ async = true, lsp_fallback = true })
+        end,
+        mode = "",
+        desc = "Run buffer through formatter",
+      },
+    },
+    opts = {
+      formatters_by_ft = {
+        lua = { "stylua" },
+        python = { "isort", "black" },
+        javascript = { { "prettierd", "prettier" } },
+        bash = { { "shfmt" } },
+        sh = { { "shfmt" } },
+      },
+      formatters = {
+        shfmt = {
+          prepend_args = { "-i", "2" },
+        },
+        stylua = {
+          prepend_args = { "--indent-type", "Spaces", "--indent-width", "2" }
+        },
+      },
+      init = function()
+        -- If you want the formatexpr, here is the place to set it
+        vim.o.formatexpr = "v:lua.require'conform'.formatexpr()"
+      end,
+    },
+  },
 }
 
 -- vim: nowrap

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+2024-03-31
+----------
+
+**vim/nvim**
+
+- new plugin, *conform.nvim*, for running formatter/stylers on buffer
+- new plugin, *flash*, which replaces *leap* for searching in buffer
+- include lsp setup for bash
+- for jumping between diagnostics, use ``]d`` rather than ``]e``
+
 2024-03-09
 ----------
 **vim/nvim**

--- a/docs/vim.rst
+++ b/docs/vim.rst
@@ -595,6 +595,10 @@ treesitter-enabled syntax highlighting though.
 
 .. versionadded:: 2023-11-01
 
+.. versionchanged:: 2024-03-31
+   Changed next diagnostic to :kbd:`]d` rather than :kbd:`]e` for better
+   mnemonic (and similar for :kbd:`[d`)
+
 `nvim-lspconfig <https://github.com/neovim/nvim-lspconfig>`_ provides access to
 nvim's Language Server Protocol (LSP). You install an LSP server for each
 language you want to use it with (see :ref:`mason` for installing these).
@@ -625,9 +629,9 @@ diagnostics.
       - Start the LSP server for this buffer
     * - :kbd:`<leader>ce`
       - Open diagnostic details
-    * - :kbd:`[e`
+    * - :kbd:`[d`
       - Prev diagnostic
-    * - :kbd:`]e`
+    * - :kbd:`]d`
       - Next diagnostic
     * - :kbd:`<leader>cgd`
       - Goto definition (e.g., when cursor is over a function)
@@ -773,6 +777,10 @@ E.g., select a hunk with :kbd:`vih`, or delete a hunk with :kbd:`dih`.
 ~~~~~~~~~~~~~~
 
 .. versionadded:: 2022-12-27
+
+.. versionchanged:: 2024-03-31
+   Version of toggleterm is pinned because later versions have issues with
+   sending multiple selected lines to the terminal.
 
 `ToggleTerm <https://github.com/akinsho/toggleterm.nvim>`_ lets you easily
 interact with a terminal within vim.
@@ -1059,9 +1067,17 @@ See the homepage for, e.g., using ``||`` to auto-create header lines.
 ~~~~~~~~~~~~~
 
 .. versionadded:: 2022-12-27
+.. versionchanged:: 2024-03-31
+   Removed in favor of the :ref:`flash` plugin, which behaves similarly but
+   also supports treesitter selections
 
-`leap <https://github.com/ggandor/leap.nvim>`_ lets you jump around in a buffer
-with low mental effort.
+
+.. _flash:
+
+``flash``
+~~~~~~~~~
+`flash <https://github.com/folke/flash.nvim>`__ lets you jump around in a buffer with low mental effort.
+
 
 .. list-table::
     :header-rows: 1
@@ -1070,18 +1086,34 @@ with low mental effort.
     * - command
       - description
 
+    * - :kbd:`Ctrl-s` when searching
+      - Toggle flash during search
+
     * - :kbd:`s` in normal mode
-      - jump below (see details)
+      - jump to match (see details)
 
     * - :kbd:`S` in normal mode
-      - jump above (see details)
+      - select this treesitter node (see details)
 
-After hitting :kbd:`s` or :kbd:`S`, type two of the characters you want to leap
-to. You will see highlighted letters pop up at all the possible destinations.
-These label possible jump points. Hit the letter corresponding to the jump
-point to go right there.
+When searching with :kbd:`/` or :kbd:`?`, **an additional suffix letter will be
+shown after each match**. Typing this additional letter lets you jump right to
+that instance.
 
-This works best when keeping your eyes on the place you want to jump to.
+Or just hit :kbd:`Enter` like normal to do a typical search.
+
+Either way, :kbd:`n` and :kbd:`N` for next/prev hit work as normal.
+
+With :kbd:`s`, this changes the syntax highlighting to hide everything but the
+search hit and the suffix.
+
+With :kbd:`S`, if a treesitter parser is installed for this filetype, suffix
+letters will be shown at different levels of the syntax tree.
+
+For example, :kbd:`S` within an R for-loop within an RMarkdown chunk will show
+suffixes to type that will select the inner body of the for-loop, the entire
+for-loop, or the entire body of the chunk. If you wanted to select the
+backticks as well, you could use :kbd:`S` when on the backticks.
+
 
 ``vim-surround``
 ~~~~~~~~~~~~~~~~
@@ -1177,6 +1209,47 @@ See the homepage for details.
 
     * - ``:DiffviewFileHistory``
       - View diffs for this file throughout git history
+
+``conform``
+~~~~~~~~~~~
+`conform <https://github.com/stevearc/conform.nvim>`__ runs style formatters on
+the current buffer.
+
+For example, if ``black`` is avaiable it will run that on the code, but in
+a way that the changes can be undone (in contrast to running ``black``
+manually on the file, which overwrites it).
+
+.. list-table::
+
+    * - command
+      - description
+
+    * - :kbd:`<leader>cf`
+      - Run configured formatter on buffer (mnemonic: [c]ode [f]ormat)
+
+You can install formatters via :ref:`mason`; search
+:file:`.config/nvim/lua/plugins.lua` for ``conform.nvim`` to see the
+configuration.
+
+For example, for Python I have ``isort`` and ``black``; for Lua, ``stylua``; for
+bash, ``shfmt``.
+
+``todo-comments``
+~~~~~~~~~~~~~~~~~
+
+`todo-comments <https://github.com/folke/todo-comments.nvim>`__ lets you jump
+across ``TODO``, ``FIXME``, ``NOTE``, and related comments within your code.
+
+.. list-table::
+
+    * - command
+      - description
+
+    * - ``:TodoTrouble``
+      - Opens trouble.nvim so you can bounce between comments
+
+    * - :kbd:`[t`, :kbd:`]t`
+      - Jump to next todo/fixme/note comment
 
 
 ``lualine``

--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,7 @@ BFG_VERSION=1.14.0
 FD_VERSION=8.5.3
 BLACK_VERSION=22.6.0
 PYP_VERSION=1.1.0
+FZF_VERSION=0.48.1
 
 function showHelp() {
 
@@ -543,12 +544,32 @@ elif [ $task == "--mac-keyboard-fix" ]; then
 
 elif [ $task == "--install-fzf" ]; then
     ok "Installs fzf (https://github.com/junegunn/fzf)"
-    (
-      git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
-      ~/.fzf/install --no-update-rc --completion --key-bindings
-    )
-    printf "${YELLOW}fzf installed; see ~/.fzf${UNSET}\n"
+    mkdir -p /tmp/fzf
+    if [[ $OSTYPE == darwin* ]]; then
+        URL=https://github.com/junegunn/fzf/releases/download/${FZF_VERSION}/fzf-${FZF_VERSION}-darwin_arm64.zip
+        download $URL /tmp/fzf/fzf.zip
+        (
+            cd /tmp/fzf
+            unzip fzf.zip
+            cp fzf ~/opt/bin
+        )
+    else
+        URL=https://github.com/junegunn/fzf/releases/download/${FZF_VERSION}/fzf-${FZF_VERSION}-linux_amd64.tar.gz
+        download $URL /tmp/fzf/fzf.tar.gz
+        (
+            cd /tmp/fzf
+            tar -xf fzf.tar.gz
+            cp fzf ~/opt/bin
+        )
+    fi
+    rm -r /tmp/fzf
 
+    if [ ! $(grep -q "(fzf --bash)" ~/.bashrc) ]; then
+        echo "" >> ~/.bashrc
+        echo "# Set up fzf keybindings and fuzzy completion" >> ~/.bashrc
+        echo 'eval "$(fzf --bash)"' >> ~/.bashrc
+    fi
+    printf "${YELLOW}fzf installed; see ~/.fzf${UNSET}\n"
 
 elif [ $task == "--install-ripgrep" ]; then
     ok "Installs ripgrep to $HOME/opt/bin"
@@ -564,6 +585,7 @@ elif [ $task == "--install-ripgrep" ]; then
     cd /tmp/rg
     tar -xf ripgrep.tar.gz
     cp ripgrep*/rg ~/opt/bin
+    rm -r /tmp/rg
     printf "${YELLOW}Installed to ~/opt/bin/rg${UNSET}\n"
     check_opt_bin_in_path
 

--- a/tests/test_commands
+++ b/tests/test_commands
@@ -4,4 +4,4 @@ black --version | head -n1	black, 22.6.0 (compiled: no)
 vd --version	saul.pw/VisiData v2.11
 rg --version | grep ripgrep	ripgrep 13.0.0 (rev af6b6c543b)
 fd --version	fd 8.5.3
-fzf --version	0.46.1 (3c0a630)
+fzf --version	0.48.1 (d579e33)


### PR DESCRIPTION
- new plugin, `conform.nvim`
- new plugin, `flash`, which replaces `leap`. Works mostly the same but also includes treesitter selections
- include LSP setup for bash
- change `]e` to `]d` for jumping to diagnostics (better mnemonic)
- now that fzf includes bash setup in binary, setup.sh now relies on github artifact for (hopefully) better version stability