### PR TITLE
added wildcard to match either nvim-macos-arm64 or nvim-macos-x86_64

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,6 +1,5 @@
 name: Docker Image CI
 
-on: [push]
 on:
   push:
     branches:

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,6 +1,15 @@
 name: Docker Image CI
 
 on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/setup.sh
+++ b/setup.sh
@@ -520,7 +520,7 @@ elif [ $task == "--install-neovim" ]; then
         xattr -c ./nvim-macos.tar.gz
         tar -xzf nvim-macos.tar.gz
         mkdir -p "$HOME/opt/bin"
-        mv nvim-macos-* "$HOME/opt/neovim"
+        mv nvim-macos-*64 "$HOME/opt/neovim"
     else
         download https://github.com/neovim/neovim/releases/download/v${NVIM_VERSION}/nvim-linux64.tar.gz nvim-linux64.tar.gz
         tar -xzf nvim-linux64.tar.gz

--- a/setup.sh
+++ b/setup.sh
@@ -520,7 +520,7 @@ elif [ $task == "--install-neovim" ]; then
         xattr -c ./nvim-macos.tar.gz
         tar -xzf nvim-macos.tar.gz
         mkdir -p "$HOME/opt/bin"
-        mv nvim-macos-arm64 "$HOME/opt/neovim"
+        mv nvim-macos-* "$HOME/opt/neovim"
     else
         download https://github.com/neovim/neovim/releases/download/v${NVIM_VERSION}/nvim-linux64.tar.gz nvim-linux64.tar.gz
         tar -xzf nvim-linux64.tar.gz


### PR DESCRIPTION
 Previously, upon unpacking the nvim download tar file, I was left with an `nvim-macos-x86_64` directory that failed to be moved to `"$HOME/opt/neovim"` because `nvim-macos-arm64` was hardcoded [here](https://github.com/menoldmt/dotfiles/blob/824d974ab2b61e234b07b244ca6efde8cbe085e2/setup.sh#L523). 
 
 resolves #47 