### PR TITLE
Make the conda env prompt more concise

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -482,7 +482,9 @@ elif [ $task == "--set-up-bioconda" ]; then
     conda config --add channels bioconda
     conda config --add channels conda-forge
     conda config --set channel_priority strict
-    echo "env_prompt: '({name}) '" >> ~/.condarc
+    if ! grep -q "env_prompt:" ~/.condarc; then
+        echo "env_prompt: '({name}) '" >> ~/.condarc
+    fi
     printf "${YELLOW}Channels configured, see ~/.condarc${UNSET}\n"
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -482,6 +482,7 @@ elif [ $task == "--set-up-bioconda" ]; then
     conda config --add channels bioconda
     conda config --add channels conda-forge
     conda config --set channel_priority strict
+    echo "env_prompt: '({name}) '" >> ~/.condarc
     printf "${YELLOW}Channels configured, see ~/.condarc${UNSET}\n"
 
 


### PR DESCRIPTION
Add to the setup.sh script so that it adds "env_prompt: '({name}) '" to the .condarc file so that the env prompt is just (\<env-name\>) instead of (\<full-path-to-env\>) after activating a conda environment.