### PR TITLE
correctly handle folders from include.file for vim diffs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2025-05-07
+----------
+
+**setup**
+
+- ``setup.sh --vim-diffs`` now correctly shows diffs from inside included directories (thanks @mitraak)
+
 2024-12-15
 ----------
 

--- a/setup.sh
+++ b/setup.sh
@@ -948,10 +948,21 @@ elif [ $task == "--diffs" ]; then
 
 elif [ $task == "--vim-diffs" ]; then
     ok "Opens up vim -d to display differences between files in this repo and your home directory. Your existing files will be on the RIGHT"
+
     for i in $(cat include.file); do
-        if ! diff $i ~/$i &> /dev/null; then
-            nvim -d $i ~/$i;
+        # if a directory, list files inside it recursively
+        # otherwise, use as is
+        if [[ -d $i ]]; then
+            all_files=$( find $i -type f )
+        else
+            all_files=( $i )
         fi
+
+        for j in ${all_files[@]}; do
+            if ! diff $j ~/$j &> /dev/null; then
+                nvim -d $j ~/$j;
+            fi
+        done
     done
 else
     showHelp


### PR DESCRIPTION
Previously, directories listed in `include.file` were not showing up correctly when running
`--vim-diffs`. This is because `setup.sh` was using `diff` to compare directories. Now,
we use `find` to recursively list all files inside any specified folder, so `--vim-diffs` work
as expected.