### PR TITLE
add pasteimg

### DIFF
--- a/.config/nvim/lua/config/autocmds.lua
+++ b/.config/nvim/lua/config/autocmds.lua
@@ -156,15 +156,26 @@ vim.api.nvim_create_autocmd("QuitPre", {
 -- terminal is in normal mode. Useful visual reminder so you don't start typing
 -- and then wonder why text is not showing up.
 
--- Custom highlight group we'll use in a moment
-vim.api.nvim_set_hl(0, "TermCursorLine", { bg = "#5f0000" })
+-- Custom highlight group we'll use in a moment. It uses the current
+-- colorscheme's Comment color
+local comment_fg = vim.api.nvim_get_hl(0, { name = "Comment" }).fg
+vim.api.nvim_set_hl(0, "TermCursorLine", { bg = comment_fg })
 
 -- winhighlight lets us render CursorLin higlights with TermCursorLine's
 -- attributes, but just local to that window (here, the terminal)
 local function apply_term_winhl()
-  if vim.bo.buftype == "terminal" then
-    vim.wo.winhighlight = "CursorLine:TermCursorLine"
+  if vim.bo.buftype ~= "terminal" then
+    return
   end
+  -- toggleterm sets its own winhighlight (Normal:ToggleTermNNormal, etc.) to
+  -- give terminals a distinct background. Append our mapping instead of
+  -- overwriting so we don't clobber it.
+  local existing = vim.wo.winhighlight
+  if existing:find("CursorLine:TermCursorLine", 1, true) then
+    return
+  end
+  vim.wo.winhighlight = (existing == "" and "" or existing .. ",")
+    .. "CursorLine:TermCursorLine"
 end
 
 local group = vim.api.nvim_create_augroup("ToggleTermCursorLine", { clear = true })
@@ -172,7 +183,11 @@ local group = vim.api.nvim_create_augroup("ToggleTermCursorLine", { clear = true
 -- Catch new terminals and existing ones
 vim.api.nvim_create_autocmd({ "TermOpen", "WinEnter", "BufWinEnter" }, {
   group = group,
-  callback = apply_term_winhl,
+  callback = function()
+    -- defer applying the window-specific highlighting so toggleterm's own
+    -- winhighlight setup runs first on TermOpen
+    vim.schedule(apply_term_winhl)
+  end,
 })
 
 -- Toggle cursorline only inside terminal windows

--- a/.config/nvim/lua/plugins/pasteimg.lua
+++ b/.config/nvim/lua/plugins/pasteimg.lua
@@ -1,0 +1,3 @@
+return {
+  "daler/pasteimg.nvim",
+}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,12 @@
 Changelog
 =========
+2026-05-07
+----------
+
+**vim**
+
+Color the cursorline in toggleterm terminal when it's not in insert mode. Gives
+a visual reminder of when typing won't do what you expect.
 
 2026-05-07
 ----------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,13 @@
 Changelog
 =========
+
+2026-05-28
+----------
+
+**vim**
+
+- Add [pasteimg](https://github.com/daler/pasteimg.nvim) plugin
+
 2026-05-07
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,9 @@ Changelog
 **vim**
 
 - Add [pasteimg](https://github.com/daler/pasteimg.nvim) plugin
+- Improve toggleterm "non-insert mode" cursorline:
+  - use the Comment color of the initially-loaded colorscheme instead of a hard-coded red
+  - don't clobber the custom background that toggleterm sets
 
 2026-05-07
 ----------

--- a/docs/nvim-plugins.rst
+++ b/docs/nvim-plugins.rst
@@ -1493,6 +1493,8 @@ and this:
 images to a remote system over SSH by locally converting the image to base64
 text on the clipboard.
 
+See the docs for the plugin on how to set it up, including a macOS Shortcut.
+
 .. list-table::
     :header-rows: 1
     :align: left
@@ -1508,31 +1510,6 @@ text on the clipboard.
 
 .. _imgclip_ref:
 
-``img-clip.nvim``
-~~~~~~~~~~~~~~~~~
-
-`img-clip.nvim <https://github.com/HakonHarnes/img-clip.nvim>`__ lets you paste
-an image on your clipboard into a Markdown, Latex, or ReST file.
-
-It detects what sort of image is on the clipboard, pastes it into a file in the
-current directory (that you name at the prompt), and inserts it as an image
-link into the document.
-
-On Mac, it needs `pngpaste <https://github.com/jcsalterego/pngpaste>`__ to be
-installed and on your PATH.
-
-.. list-table::
-    :header-rows: 1
-    :align: left
-
-    * - command
-      - description
-
-    * - :kbd:`<leader>P`
-      - Paste image on clipboard
-
-.. plugin-metadata::
-   :name: img-clip
 
 .. colorschemes_ref:
 
@@ -1636,6 +1613,14 @@ Deprecated plugins
 .. plugin-metadata::
    :name: vim-sleuth
    :deprecation: vim-sleuth would often get things wrong. indent-o-matic's simpler algorithm seems to work better.
+
+``img-clip.nvim``
+~~~~~~~~~~~~~~~~~
+
+.. plugin-metadata::
+   :name: img-clip.nvim
+   :deprecation: This was only included for a short time; it didn't work on remote systems so I wrote :ref:`pasteimg_ref` and used that instead.
+
 
 Notes on tried plugins
 ----------------------

--- a/docs/nvim-plugins.rst
+++ b/docs/nvim-plugins.rst
@@ -1085,6 +1085,10 @@ the terminal use.
     terminal, or use :kbd:`a` or :kbd:`i` in the terminal to get back to insert
     mode.
 
+    Starting from 2026-05-07, when the terminal is not in insert mode, the
+    terminal-specific cursorline will be a different color to help indicate the
+    status.
+
 .. list-table::
     :header-rows: 1
     :align: left
@@ -1479,6 +1483,28 @@ and this:
 
 .. plugin-metadata::
    :name: treesj
+
+.. _pasteimg_ref:
+
+``pasteimg.nvim``
+~~~~~~~~~~~~~~~~~
+
+`pasteimg.nvim <https://github.com/daler/pasteimg.nvim>`__ supports pasting
+images to a remote system over SSH by locally converting the image to base64
+text on the clipboard.
+
+.. list-table::
+    :header-rows: 1
+    :align: left
+
+    * - command
+      - description
+
+    * - ``:PasteImgFromPayload`` on a line
+      - Converts the base64 text on the line to an image, saves it, and inserts a link to it.
+
+.. plugin-metadata::
+   :name: pasteimg
 
 .. _imgclip_ref:
 


### PR DESCRIPTION
Add [pasteimg](https://github.com/daler/pasteimg.nvim) plugin for adding images to a remote ReST/markdown document.

Also adjusts the terminal window's cursorline indication to inherit the comment color of the colorscheme rather than a hard-coded red.