### PR TITLE
R.nvim, take 2

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,3 @@
+# This restricts the number of CPUs that can be used by the R.nvim plugin.
+# Needs R.nvim >=0.9.96
+options(nvimcom.max_cpu_cores = max(2, as.numeric(Sys.getenv("SLURM_CPUS_PER_TASK")), na.rm=TRUE))

--- a/.config/nvim/lua/config/autocmds.lua
+++ b/.config/nvim/lua/config/autocmds.lua
@@ -156,15 +156,26 @@ vim.api.nvim_create_autocmd("QuitPre", {
 -- terminal is in normal mode. Useful visual reminder so you don't start typing
 -- and then wonder why text is not showing up.
 
--- Custom highlight group we'll use in a moment
-vim.api.nvim_set_hl(0, "TermCursorLine", { bg = "#5f0000" })
+-- Custom highlight group we'll use in a moment. It uses the current
+-- colorscheme's Comment color
+local comment_fg = vim.api.nvim_get_hl(0, { name = "Comment" }).fg
+vim.api.nvim_set_hl(0, "TermCursorLine", { bg = comment_fg })
 
 -- winhighlight lets us render CursorLin higlights with TermCursorLine's
 -- attributes, but just local to that window (here, the terminal)
 local function apply_term_winhl()
-  if vim.bo.buftype == "terminal" then
-    vim.wo.winhighlight = "CursorLine:TermCursorLine"
+  if vim.bo.buftype ~= "terminal" then
+    return
   end
+  -- toggleterm sets its own winhighlight (Normal:ToggleTermNNormal, etc.) to
+  -- give terminals a distinct background. Append our mapping instead of
+  -- overwriting so we don't clobber it.
+  local existing = vim.wo.winhighlight
+  if existing:find("CursorLine:TermCursorLine", 1, true) then
+    return
+  end
+  vim.wo.winhighlight = (existing == "" and "" or existing .. ",")
+    .. "CursorLine:TermCursorLine"
 end
 
 local group = vim.api.nvim_create_augroup("ToggleTermCursorLine", { clear = true })
@@ -172,7 +183,11 @@ local group = vim.api.nvim_create_augroup("ToggleTermCursorLine", { clear = true
 -- Catch new terminals and existing ones
 vim.api.nvim_create_autocmd({ "TermOpen", "WinEnter", "BufWinEnter" }, {
   group = group,
-  callback = apply_term_winhl,
+  callback = function()
+    -- defer applying the window-specific highlighting so toggleterm's own
+    -- winhighlight setup runs first on TermOpen
+    vim.schedule(apply_term_winhl)
+  end,
 })
 
 -- Toggle cursorline only inside terminal windows

--- a/.config/nvim/lua/config/autocmds.lua
+++ b/.config/nvim/lua/config/autocmds.lua
@@ -207,3 +207,16 @@ vim.api.nvim_create_autocmd("ModeChanged", {
     vim.wo.cursorline = vim.api.nvim_get_mode().mode == "nt"
   end,
 })
+
+
+-- Always use insert mode when entering a terminal buffer, even with mouse click.
+-- NOTE: Clicking with a mouse a second time enters visual select mode, just like in a text buffer.
+vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter" }, {
+  pattern = "*",
+  callback = function()
+    if vim.bo.buftype == "terminal" then
+      vim.cmd("startinsert")
+    end
+  end,
+})
+

--- a/.config/nvim/lua/plugins/blink.lua
+++ b/.config/nvim/lua/plugins/blink.lua
@@ -9,6 +9,9 @@ local has_words_before = function()
   local line = vim.api.nvim_get_current_line()
   return line:sub(col, col):match("%s") == nil
 end
+
+-- Only enable dictionary completion if a system word list is available
+local has_dictionary = vim.uv.fs_stat('/usr/share/dict/words') ~= nil
 return {
   "saghen/blink.cmp",
   dependencies = {
@@ -49,22 +52,22 @@ return {
         local result = { 'lsp', 'path', 'snippets', 'buffer' }
 
         -- turn on dictionary completion in non-code files
-        if vim.tbl_contains({ 'markdown', 'text', 'rst' }, vim.bo.filetype) then
+        if has_dictionary and vim.tbl_contains({ 'markdown', 'text', 'rst' }, vim.bo.filetype) then
           table.insert(result, 'dictionary')
         end
         return result
       end,
-      providers = {
+      providers = has_dictionary and {
         dictionary = {
           module = 'blink-cmp-dictionary',
           name = 'Dict',
           min_keyword_length = 3,
           opts = {
             -- This is the location of the word list on macOS and many Linux distributions
-            dictionary_files = { '/usr/share/dict/words' }
-          }
-        }
-      },
+            dictionary_files = { '/usr/share/dict/words' },
+          },
+        },
+      } or {},
     },
     fuzzy = { implementation = "prefer_rust_with_warning" },
     completion = {

--- a/.config/nvim/lua/plugins/pasteimg.lua
+++ b/.config/nvim/lua/plugins/pasteimg.lua
@@ -1,0 +1,3 @@
+return {
+  "daler/pasteimg.nvim",
+}

--- a/.config/nvim/lua/plugins/r-nvim.lua
+++ b/.config/nvim/lua/plugins/r-nvim.lua
@@ -2,9 +2,6 @@
 return {
   "R-nvim/R.nvim",
 
-  -- Current latest version (0.99.5) doesn't fully support old R versions.
-  version="0.99.4",
-
   -- Only load the plugin if we can find an executable for R.
   cond = function()
     return vim.fn.executable("R") == 1
@@ -16,6 +13,7 @@ return {
     Rout_follow_colorscheme=true,
     -- config_tmux=false,
     rconsole_width=80,
+
 
     -- by default, :RDSendLine will send the entire block (entire for-loop or entire function, for example). Disabling this sends just one line at a time.
     parenblock=false,

--- a/.config/nvim/lua/plugins/r-nvim.lua
+++ b/.config/nvim/lua/plugins/r-nvim.lua
@@ -1,0 +1,65 @@
+-- Integration with a running R interpreter
+return {
+  "R-nvim/R.nvim",
+
+  -- Current latest version (0.99.5) doesn't fully support old R versions.
+  version="0.99.4",
+
+  -- Only load the plugin if we can find an executable for R.
+  cond = function()
+    return vim.fn.executable("R") == 1
+  end,
+
+  opts = {
+    -- These support syntax highlighting in the R interpreter
+    Rout_more_colors=true,
+    Rout_follow_colorscheme=true,
+    -- config_tmux=false,
+    rconsole_width=80,
+
+    -- by default, :RDSendLine will send the entire block (entire for-loop or entire function, for example). Disabling this sends just one line at a time.
+    parenblock=false,
+   min_editor_width=18,
+    view_df = {
+      -- open a dataframe with <localleader>rv in visidata in a new nvim terminal window.
+      -- Note: using tmux as per the docs does not work when on an interactive
+      -- node, so we use local terminal here.
+      open_app = "terminal:vd",
+    },
+    r_ls = {
+      -- Completion lists are created by the built-in language server per
+      -- package, per version. It can take a while to build completion lists,
+      -- especially when you bounce between environments. They are cached
+      -- though, so it's a one-time cost. If you're OK paying that cost for
+      -- convenient completion, set completion = true (which is the default)
+      completion = false,
+    },
+
+    hook = {
+       on_filetype = function()
+         vim.api.nvim_buf_set_keymap(0, "n", "gxx", "<Plug>RDSendLine", {})
+         vim.api.nvim_buf_set_keymap(0, "v", "gx", "<Plug>RSendSelection", {})
+         vim.api.nvim_buf_set_keymap(0, "n", ",cd", "<Plug>RDSendChunk", {})
+         vim.api.nvim_buf_set_keymap(0, "n", "<leader>k", "<Plug>RSend rmarkdown::render('%p')<CR>", {})
+         vim.keymap.set("n", "<leader>k",
+          function()
+           local path = vim.api.nvim_buf_get_name(0)
+           require("r.send").cmd('rmarkdown::render("' .. path .. '")')
+          end,
+          { buffer = true, desc = "Render Rmarkdown" })
+
+        -- In 0.99.4 which is used here for compatibility with older
+        -- R versions, the RDSendLine command sends the entire treesitter block
+        -- (entire function, entire for-loop, etc) rather than just one line.
+        -- This is fixed in 0.99.5, but patching here so we can use it with 0.99.4.
+        -- The behavior is still accessible with the default <localleader>d.
+        vim.keymap.set("n", "gxx", function()
+          local line = vim.api.nvim_get_current_line()
+          require("r.send").cmd(line)
+          vim.cmd("normal! j")
+        end, { buffer = true })
+      end,
+    },
+  },
+  lazy=false
+}

--- a/.config/nvim/lua/plugins/toggleterm.lua
+++ b/.config/nvim/lua/plugins/toggleterm.lua
@@ -18,15 +18,6 @@ return {
         end,
       })
 
-      -- Always use insert mode when entering a terminal buffer, even with mouse click.
-      -- NOTE: Clicking with a mouse a second time enters visual select mode, just like in a text buffer.
-      vim.api.nvim_create_autocmd("BufEnter", {
-        pattern = "*",
-        callback = function()
-          vim.cmd("if &buftype == 'terminal' | startinsert | endif")
-        end,
-      })
-
       -- Patch toggleterm to use bracketed paste (special escape codes before
       -- and after the text to be pasted)
       -- https://en.wikipedia.org/wiki/Bracketed-paste

--- a/.functions
+++ b/.functions
@@ -121,3 +121,90 @@ function git-clean-branches () {
 
     echo "Use 'git-clean-branches | xargs git branch -d' to actually delete these." >&2
 }
+
+
+
+# nvimcom is the R package that the Neovim plugin R.nvim uses to talk to
+# a running R session. It's a compiled package, so it must be built against the
+# exact R version in use.
+#
+# To support multiple R versions side by side, we install it into a per-version
+# "sidecar" library under ~/R/nvimcom/<version> rather than into R's default
+# user library. The correct nvimcom package is added to R_LIBS_USER with the
+# Ropen function.
+#
+# In this way, we can use R.nvim with any version of R without installing it
+# into the respective R's environment.
+
+# Echo the X.Y.Z version of the R currently on PATH (empty + nonzero on failure).
+_r_version() {
+    command -v R &>/dev/null || return 1
+    R --version 2>/dev/null | grep -Eom1 '[0-9]+\.[0-9]+\.[0-9]+'
+}
+
+install-nvimcom() {
+    local nvimcom_src bundled_version r_version sidecar_lib installed_desc install_log min_r
+
+    # nvimcom's source ships inside the R.nvim plugin (installed via lazy.nvim).
+    nvimcom_src="$HOME/.local/share/nvim/lazy/R.nvim/nvimcom"
+    [[ -d "$nvimcom_src" ]] || {
+        echo "ERROR: nvimcom source not found at $nvimcom_src."
+        return 1
+    }
+
+    r_version=$(_r_version) || {
+        echo "ERROR: No R on PATH."
+        return 1
+    }
+    bundled_version=$(awk '/^Version:/{print $2}' "$nvimcom_src/DESCRIPTION")
+    sidecar_lib="$HOME/R/nvimcom/$r_version"
+    installed_desc="$sidecar_lib/nvimcom/DESCRIPTION"
+
+    # Refuse to build against an R that's too old. nvimcom is compiled C code;
+    # a too-old R compiles fine (C only warns on implicit declarations) but
+    # fails at load with a cryptic "undefined symbol" error. Catch it here
+    # instead by honoring the minimum R version from nvimcom's DESCRIPTION.
+    min_r=$(grep -oE 'R \(>= [0-9]+\.[0-9]+(\.[0-9]+)?\)' "$nvimcom_src/DESCRIPTION" \
+        | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?')
+    if [[ -n "$min_r" ]] &&
+        [[ "$(printf '%s\n%s\n' "$min_r" "$r_version" | sort -V | head -1)" != "$min_r" ]]; then
+        echo "ERROR: nvimcom $bundled_version requires R >= $min_r, but R $r_version is on PATH."
+        echo "       Put a newer R on PATH, or pin an older R.nvim/nvimcom."
+        return 1
+    fi
+
+    # Skip the build if the sidecar already has the matching version installed.
+    if [[ -f "$installed_desc" ]] &&
+        [[ "$(awk '/^Version:/{print $2}' "$installed_desc")" == "$bundled_version" ]]; then
+        return 0
+    fi
+
+    # Build into the sidecar. R_LIBS_USER is set so build-time dependency
+    # lookups also resolve against the sidecar.
+    echo "Installing nvimcom $bundled_version for R $r_version ..."
+    mkdir -p "$sidecar_lib"
+    install_log="/tmp/nvimcom-install-$r_version.log"
+    if R_LIBS_USER="$sidecar_lib" R CMD INSTALL --library="$sidecar_lib" "$nvimcom_src" >"$install_log" 2>&1; then
+        echo "✓ nvimcom $bundled_version installed for R $r_version."
+    else
+        echo "✗ Failed — see $install_log"
+        return 1
+    fi
+}
+
+Ropen() {
+    # Opens $EDITOR (Neovim) for an R session, making sure the version-matched
+    # nvimcom sidecar library exists and is on R_LIBS_USER so R.nvim can use it.
+    local r_version sidecar_lib
+    r_version=$(_r_version) || {
+        echo "No R found on PATH."
+        return 1
+    }
+
+    install-nvimcom || return 1
+
+    # Prepend the sidecar to R_LIBS_USER (keeping the normal user library too).
+    sidecar_lib="$HOME/R/nvimcom/$r_version"
+    R_LIBS_USER="$sidecar_lib:${R_LIBS_USER:-$HOME/R/library}" $EDITOR "$@"
+}
+

--- a/.functions
+++ b/.functions
@@ -208,3 +208,69 @@ Ropen() {
     R_LIBS_USER="$sidecar_lib:${R_LIBS_USER:-$HOME/R/library}" $EDITOR "$@"
 }
 
+# ---------------------------------------------------------------------------
+# Attach "sidecar" IPython to debug another environment
+# ---------------------------------------------------------------------------
+#
+# Sometimes you need to debug a conda environment, which IPython is great for,
+# but you may not want to install IPython into the env itself (since that would
+# be injecting a debugging tool preference into the reproducible environment).
+#
+# So given an env you want to work on, this function will create (if it doesn't
+# exist) a Python-matched named env env (of the form "ipython_X.Y") containing
+# just IPython, and then attach the target env's Python packages to it. The
+# result is that everything works as if you *had* installed IPython into the
+# target env.
+function attach-ipython(){
+
+    if [ $# -lt 1 ]; then
+        echo "Usage: attach-ipython <conda-env-path>" >&2
+        return 1
+    fi
+
+    # Resolve the target env path and see if it has python
+    local ENV_PATH
+    ENV_PATH="$(cd "$1" 2>/dev/null && pwd)" || { echo "Not a directory: $1" >&2; return 1; }
+    if [ ! -x "$ENV_PATH/bin/python" ]; then
+        echo "No python found at $ENV_PATH/bin/python" >&2
+        return 1
+    fi
+
+    # Detect Python version from the target env
+    local PY_VERSION DEBUG_ENV SITE_PKGS
+    PY_VERSION="$("$ENV_PATH/bin/python" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+    DEBUG_ENV="ipython_${PY_VERSION}"
+
+    # Create the debug env if it doesn't exist. Match on the exact env name
+    # (first whitespace-separated field) so the active-env '*' marker and
+    # column alignment don't throw off the check.
+    if ! conda env list | awk '{print $1}' | grep -qx "$DEBUG_ENV"; then
+        echo "Creating debug env '${DEBUG_ENV}' with Python ${PY_VERSION}..."
+        conda create -y -n "$DEBUG_ENV" "python=${PY_VERSION}" ipython
+    else
+        echo "Debug env '${DEBUG_ENV}' already exists."
+    fi
+
+    # Find site-packages in the target env (join all entries in case there is
+    # more than one).
+    SITE_PKGS="$("$ENV_PATH/bin/python" -c 'import site, os; print(os.pathsep.join(site.getsitepackages()))')"
+
+    # Run everything in a subshell to avoid the parent shell having an
+    # activated debug env and a modified PYTHONPATH.
+    #
+    # Note: the target env's site-packages is prepended, so its package
+    # versions take precedence over the debug env's. This is intentional (we
+    # want to debug the target's packages), but if the target ships
+    # incompatible versions of IPython's own dependencies (traitlets,
+    # prompt_toolkit, jedi, ...) IPython may fail to start.
+    (
+        eval "$(conda shell.bash hook)"
+        conda activate "$DEBUG_ENV"
+
+        export PYTHONPATH="${SITE_PKGS}${PYTHONPATH:+:$PYTHONPATH}"
+        echo "PYTHONPATH=${PYTHONPATH}"
+        echo "Attached to: ${ENV_PATH} (Python ${PY_VERSION})"
+
+        ipython "${@:2}"
+    )
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ ADD \
 .path \
 .tmux.conf \
 .vimrc \
+.Rprofile \
 apt-installs.txt \
 include.file \
 requirements-mac.txt \

--- a/docs/bash.rst
+++ b/docs/bash.rst
@@ -164,6 +164,12 @@ are set up. Some notable functions defined here:
         :file:`.ssh/config` file. Useful for when you're trying to remember how
         to log in to an infrequently-accessed host.
 
+    * - ``attach-ipython``
+      - Given a target conda env path, start IPython (creating a named env if
+        needed) and add the target conda env's Python libraries to PYTHONPATH
+        such that IPython can be used with the target env without needing to
+        install it *into* the env.
+
 
 .. _.bash_prompt:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,12 +1,23 @@
 Changelog
 =========
 
+2026-06-14
+----------
+
+**vim**
+
+Add experimental R.nvim plugin support, including additional functions
+``Ropen`` and ``install-nvimcom`` in :file:`.functions`.
+
+Currently not fully functional due to tab completion database resource usage.
+
 2026-05-28
 ----------
 
 **vim**
 
 - Add [pasteimg](https://github.com/daler/pasteimg.nvim) plugin
+- Remove ``img-clip`` plugin (which didn't work on remote systems)
 - Improve toggleterm "non-insert mode" cursorline:
   - use the Comment color of the initially-loaded colorscheme instead of a hard-coded red
   - don't clobber the custom background that toggleterm sets

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,14 @@ Changelog
 the tab-completion database resource usage has been addressed. Make sure to
 include the :file:`~/.Rprofile` addition documented at :ref:`rnvim_ref`.
 
+For the ``blink`` nvim plugin, only enable the dictionary if the expected path
+(:file:`/usr/share/dict/words`) exists
+
+Sometimes on an interactive node the expected dictionary file
+:file:`/usr/share/dict/words` does not exist, causing repeated errors when
+editing ReST, text, or markdown files. This completion source is now disabled
+if that path doesn't exist, avoiding those errors.
+
 2026-06-14
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,12 @@
 Changelog
 =========
+2026-05-07
+----------
+
+**vim**
+
+Color the cursorline in toggleterm terminal when it's not in insert mode. Gives
+a visual reminder of when typing won't do what you expect.
 
 2026-05-07
 ----------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,10 @@ Sometimes on an interactive node the expected dictionary file
 editing ReST, text, or markdown files. This completion source is now disabled
 if that path doesn't exist, avoiding those errors.
 
+**Python**
+
+Add the new ``attach-ipython`` bash function, see :ref:`.functions`.
+
 2026-06-14
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,13 @@
 Changelog
 =========
+
+2026-05-28
+----------
+
+**vim**
+
+- Add [pasteimg](https://github.com/daler/pasteimg.nvim) plugin
+
 2026-05-07
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+2026-06-26
+----------
+
+**vim**
+
+``R.nvim`` no longer experimental. With new versions of ``R.nvim`` (>0.9.96),
+the tab-completion database resource usage has been addressed. Make sure to
+include the :file:`~/.Rprofile` addition documented at :ref:`rnvim_ref`.
+
 2026-06-14
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,9 @@ Changelog
 **vim**
 
 - Add [pasteimg](https://github.com/daler/pasteimg.nvim) plugin
+- Improve toggleterm "non-insert mode" cursorline:
+  - use the Comment color of the initially-loaded colorscheme instead of a hard-coded red
+  - don't clobber the custom background that toggleterm sets
 
 2026-05-07
 ----------

--- a/docs/nvim-plugins.rst
+++ b/docs/nvim-plugins.rst
@@ -1508,10 +1508,131 @@ See the docs for the plugin on how to set it up, including a macOS Shortcut.
 .. plugin-metadata::
    :name: pasteimg
 
-.. _imgclip_ref:
+.. _rnvim_ref:
+
+``r.nvim``
+~~~~~~~~~~
+
+`R.nvim <https://github.com/R-nvim/R.nvim/>`__ provides tight integration with R running in an nvim terminal.
+
+.. warning::
+
+   **This is experimental.**
+
+   Currently the biggest issue is the creation of the tab-completion database.
+   ``nvimcom`` does this at startup, and with no apparent working way of
+   disabling it on the nvim side. It does this for *each installed R library*.
+   If you use this on an all-in-one installation, like the one for Biowulf's
+   ``module load R``, it will consume all resources on the node.
+
+   For something like a project-specific R environment, it does take a couple
+   minutes the first time on a big node, but using the same env after that is
+   instant.
+
+   Another issue is support for old R versions. Currently, R.nvim v0.99.4
+   cleanly supports old R versions but 0.99.5 does not (despite release notes
+   to the contrary). This will likely change since the plugin is under active
+   development.
 
 
-.. colorschemes_ref:
+This provides more features than simply running R in an nvim terminal (like
+with :ref:`toggleterm_ref`).
+
+- R object browser (like the panel in RStudio)
+- quickly view a dataframe in Visidata (like``View()`` in RStudio)
+- tab-completion of functions and arguments
+- syntax highlighting in the R interpreter
+- R documentation within text buffer
+- An R language server that doesn't itself require R (specifically, it doesn't
+  require being installed into the same environment as R)
+- More flexibility in controlling what is sent to the terminal
+- Insert commented version of output into the text buffer (great for
+  ``head(df)`` so your comments reflect what's in the data.frame)
+- Send ``str`` with the name of the object under the cursor for quick inspection in R
+- Jump through an RMarkdown file by chunk
+- Lots more...
+
+In order for this to work, the ``nvimcom`` package needs to be installed into
+the environment with R. However, it didn't seem right to "contaminate" an
+otherwise reproducible R environment with a package just for personal editing
+preferences.
+
+To use this additional functionality, you need to do the following two steps:
+
+- Activate the environment you want to use, on the host you want to use. If
+  you're running R on an interactive node, you need to be *running nvim on the
+  interactive node*.
+- Use ``Ropen <filename>`` to start nvim with the right env vars set. This
+  function is now included in the updated :file:`.functions` file of these
+  dotfiles. It also uses the ``install-nvimcom`` function from that file.
+
+
+.. details:: What these functions do
+
+   ``nvimcom`` is compiled. The source code lives in this nvim plugin, but it
+   needs to be compiled on the R version you're using. The trick here is that
+   we're compiling it the first time you use it for an R version, but storing it
+   in a "sidecar" library.
+
+   ``Ropen`` checks the
+   version of R on the path, pulls the source from the nvim plugin directory,
+   compiles nvimcom if it needs to using that R and stores it in
+   :file:`~/R/nvimcom/<X.Y.Z>` (that's the sidecar library), sets the
+   ``R_LIBS_USER`` env var to point to that sidecar library, and launches R.
+
+.. note::
+
+   R.nvim uses ``<localleader>`` instead of ``<leader>``. This essentially
+   allows another whole namespace to put shortcuts.
+
+   By default ``<localleader>`` is ``\\`` (backslash).
+
+   Commands that do the same thing as :ref:`toggleterm_ref` (``gx``, ``gxx``,
+   ``,cd``, ``,k``) have been remapped to match existing toggleterm so you can
+   take advantage of existing muscle memory.
+
+.. list-table::
+    :header-rows: 1
+    :align: left
+
+    * - command
+      - description
+
+    * - ``<localleader>rf``
+      - Starts an R session that communicates with nvimcom
+
+    * - ``gxx`` on a line
+      - Send line to R (like :ref:`toggleterm_ref`)
+
+    * - ``gx`` on a selection
+      - Send selection to R (like :ref:`toggleterm_ref`)
+
+    * - ``<leader>cd``
+      - Send chunk to R (like :ref:`toggleterm_ref`)
+
+    * - ``<leader>k``
+      - Render RMarkdown to HTML (like :ref:`toggleterm_ref`)
+
+    * - ``<localleader>o``
+      - Open R object browser
+
+    * - ``<localleader>rv`` with the cursor on a dataframe variable
+      - Open a new nvim terminal to view the data frame in visidata. ``q``
+        quits visidata and the terminal.
+
+    * - ``<localleader>ro``
+      - Run the line under the cursor in R, capture the output, and paste it
+        under the cursor -- but commented out. Useful for documenting data
+        structures.
+
+    * - ``:RMapsDesc``
+      - List all the other commands possible
+
+
+.. plugin-metadata::
+   :name: r-nvim
+
+.. _colorschemes_ref:
 
 Colorschemes
 ------------

--- a/docs/nvim-plugins.rst
+++ b/docs/nvim-plugins.rst
@@ -1515,81 +1515,106 @@ See the docs for the plugin on how to set it up, including a macOS Shortcut.
 
 `R.nvim <https://github.com/R-nvim/R.nvim/>`__ provides tight integration with R running in an nvim terminal.
 
-.. warning::
+.. note::
 
-   **This is experimental.**
-
-   Currently the biggest issue is the creation of the tab-completion database.
-   ``nvimcom`` does this at startup, and with no apparent working way of
-   disabling it on the nvim side. It does this for *each installed R library*.
-   If you use this on an all-in-one installation, like the one for Biowulf's
-   ``module load R``, it will consume all resources on the node.
-
-   For something like a project-specific R environment, it does take a couple
-   minutes the first time on a big node, but using the same env after that is
-   instant.
-
-   Another issue is support for old R versions. Currently, R.nvim v0.99.4
-   cleanly supports old R versions but 0.99.5 does not (despite release notes
-   to the contrary). This will likely change since the plugin is under active
-   development.
+   The existing method of using :ref:`toggleterm_ref` for R (or any other
+   terminal) remains the same. This is a new optional method that is specific
+   to R, with key mappings deliberately set to be similar to the toggleterm
+   method.
 
 
-This provides more features than simply running R in an nvim terminal (like
+R.nvim provides more features than simply running R in an nvim terminal (like
 with :ref:`toggleterm_ref`).
 
-- R object browser (like the panel in RStudio)
-- quickly view a dataframe in Visidata (like``View()`` in RStudio)
-- tab-completion of functions and arguments
-- syntax highlighting in the R interpreter
-- R documentation within text buffer
-- An R language server that doesn't itself require R (specifically, it doesn't
-  require being installed into the same environment as R)
+- R object browser (like using the object panel in RStudio); hit Enter on
+  an object to view
+- View a dataframe in Visidata (like using ``View()`` in RStudio)
+- Help opens in a new nvim split (rather than in the R terminal)
+- Tab-completion of functions and arguments within the text buffer
+- Large amounts of text sent to R interpreter are bundled, only reporting
+  a single line confirmation. This avoids cluttering the interpreter.
+- Syntax highlighting in the R interpreter
+- An R language server that doesn't itself require R
 - More flexibility in controlling what is sent to the terminal
-- Insert commented version of output into the text buffer (great for
-  ``head(df)`` so your comments reflect what's in the data.frame)
+- Insert a commented version of output into the text buffer. This is great for
+  ``head(df)`` so your comments show contents of the data.frame.
 - Send ``str`` with the name of the object under the cursor for quick inspection in R
 - Jump through an RMarkdown file by chunk
+- ``eval=FALSE`` chunks are highlighted as commented text for a visual reminder.
 - Lots more...
 
-In order for this to work, the ``nvimcom`` package needs to be installed into
-the environment with R. However, it didn't seem right to "contaminate" an
-otherwise reproducible R environment with a package just for personal editing
-preferences.
+**This additional functionality requires the following two steps:**
 
-To use this additional functionality, you need to do the following two steps:
-
-- Activate the environment you want to use, on the host you want to use. If
-  you're running R on an interactive node, you need to be *running nvim on the
-  interactive node*.
-- Use ``Ropen <filename>`` to start nvim with the right env vars set. This
-  function is now included in the updated :file:`.functions` file of these
-  dotfiles. It also uses the ``install-nvimcom`` function from that file.
-
+1. Nvim and R must be running on the same host.
+   - E.g., activate the environment *before starting nvim* that you want to
+     use, on the host you want to use.
+   - If you're running R on an interactive node, you need to be running nvim on
+     the interactive node as well. This is different from using toggleterm,
+     where you can start nvim on the login node, start a terminal, and log into
+     the interactive node from there.
+2. Use ``Ropen <filename>``.
+   - Don't use ``nvim <filename>``
+   - ``Ropen`` starts nvim with with the right env vars set. This ``Ropen``
+     function is now included in the updated :file:`.functions` file of these
+     dotfiles, so make sure you have that. It also uses the ``install-nvimcom``
+     function, also from :file:`.functions`.
 
 .. details:: What these functions do
 
-   ``nvimcom`` is compiled. The source code lives in this nvim plugin, but it
-   needs to be compiled on the R version you're using. The trick here is that
-   we're compiling it the first time you use it for an R version, but storing it
-   in a "sidecar" library.
+   In order for all of this to work, the ``nvimcom`` package needs to be
+   installed into the environment with R.
 
-   ``Ropen`` checks the
-   version of R on the path, pulls the source from the nvim plugin directory,
-   compiles nvimcom if it needs to using that R and stores it in
-   :file:`~/R/nvimcom/<X.Y.Z>` (that's the sidecar library), sets the
-   ``R_LIBS_USER`` env var to point to that sidecar library, and launches R.
+   However, it didn't seem right to "contaminate" an otherwise reproducible
+   R environment with a package used only for personal editing preferences.
 
-.. note::
 
-   R.nvim uses ``<localleader>`` instead of ``<leader>``. This essentially
-   allows another whole namespace to put shortcuts.
+   In addition, ``nvimcom`` is compiled. The source code lives in this nvim
+   plugin, but it needs to be compiled with the exact R version you're using.
 
-   By default ``<localleader>`` is ``\\`` (backslash).
+   The trick here is that we're compiling it the first time you use it for an
+   R version, but storing it in a "sidecar" library outside the main
+   R environment. Then we're telling R about that sidecar library only when we
+   want to use R.nvim.
 
-   Commands that do the same thing as :ref:`toggleterm_ref` (``gx``, ``gxx``,
-   ``,cd``, ``,k``) have been remapped to match existing toggleterm so you can
-   take advantage of existing muscle memory.
+   The ``Ropen`` function, now available in :file:`.functions` does the following:
+
+   - checks the version of R on the path (i.e. from an activated environment)
+   - check to see if we already have a compiled sidecar library for this version
+   - if not, compiles it with the function ``install-nvimcom``, which:
+     - pulls the ``nvimcom`` source from the nvim plugin directory
+     - compiles it against the R version on the path
+     - stores it in :file:`~/R/nvimcom/<X.Y.Z>` (that's the sidecar library)
+   - sets the ``R_LIBS_USER`` env var to point to the sidecar library for this
+     version of R containing the compiled ``nvimcom``
+   - With all that set up, then runs ``nvim <filename>`` to open the file.
+
+
+When using an HPC system (like Biowulf), **you must put the following** in your
+:file:`~/.Rprofile`:
+
+.. code-block:: r
+
+    # This restricts the number of CPUs that can be used by the R.nvim plugin.
+    # Needs R.nvim >=0.9.96
+    options(nvimcom.max_cpu_cores = max(2, as.numeric(Sys.getenv("SLURM_CPUS_PER_TASK")), na.rm=TRUE))
+
+.. warning::
+
+   By default, R.nvim will try to grab **all CPUs on the hardware** in order to
+   build the tab-completion database. This will crash an interactive node on an
+   HPC system. You **must** edit your :file:`.Rprofile` as shown above to avoid
+   this.
+
+This plugin is **only activated when an R or Rmd file is opened**.
+
+R.nvim uses ``<localleader>`` instead of ``<leader>``. This essentially
+allows another whole namespace in which to put shortcuts.
+
+By default ``<localleader>`` is ``\\`` (backslash).
+
+Commands that do the same thing as :ref:`toggleterm_ref` (``gx``, ``gxx``,
+``,cd``, ``,k``) have been remapped to match existing toggleterm so you can
+take advantage of existing muscle memory.
 
 .. list-table::
     :header-rows: 1
@@ -1626,7 +1651,7 @@ To use this additional functionality, you need to do the following two steps:
         structures.
 
     * - ``:RMapsDesc``
-      - List all the other commands possible
+      - List all the other commands possible. There are a lot.
 
 
 .. plugin-metadata::

--- a/docs/nvim-plugins.rst
+++ b/docs/nvim-plugins.rst
@@ -1493,6 +1493,8 @@ and this:
 images to a remote system over SSH by locally converting the image to base64
 text on the clipboard.
 
+See the docs for the plugin on how to set it up, including a macOS Shortcut.
+
 .. list-table::
     :header-rows: 1
     :align: left
@@ -1508,31 +1510,6 @@ text on the clipboard.
 
 .. _imgclip_ref:
 
-``img-clip.nvim``
-~~~~~~~~~~~~~~~~~
-
-`img-clip.nvim <https://github.com/HakonHarnes/img-clip.nvim>`__ lets you paste
-an image on your clipboard into a Markdown, Latex, or ReST file.
-
-It detects what sort of image is on the clipboard, pastes it into a file in the
-current directory (that you name at the prompt), and inserts it as an image
-link into the document.
-
-On Mac, it needs `pngpaste <https://github.com/jcsalterego/pngpaste>`__ to be
-installed and on your PATH.
-
-.. list-table::
-    :header-rows: 1
-    :align: left
-
-    * - command
-      - description
-
-    * - :kbd:`<leader>P`
-      - Paste image on clipboard
-
-.. plugin-metadata::
-   :name: img-clip
 
 .. colorschemes_ref:
 
@@ -1636,6 +1613,14 @@ Deprecated plugins
 .. plugin-metadata::
    :name: vim-sleuth
    :deprecation: vim-sleuth would often get things wrong. indent-o-matic's simpler algorithm seems to work better.
+
+``img-clip.nvim``
+~~~~~~~~~~~~~~~~~
+
+.. plugin-metadata::
+   :name: img-clip.nvim
+   :deprecation: This was only included for a short time; it didn't work on remote systems so I wrote :ref:`pasteimg_ref` and used that instead.
+
 
 Notes on tried plugins
 ----------------------

--- a/docs/nvim-plugins.rst
+++ b/docs/nvim-plugins.rst
@@ -1085,6 +1085,10 @@ the terminal use.
     terminal, or use :kbd:`a` or :kbd:`i` in the terminal to get back to insert
     mode.
 
+    Starting from 2026-05-07, when the terminal is not in insert mode, the
+    terminal-specific cursorline will be a different color to help indicate the
+    status.
+
 .. list-table::
     :header-rows: 1
     :align: left
@@ -1479,6 +1483,28 @@ and this:
 
 .. plugin-metadata::
    :name: treesj
+
+.. _pasteimg_ref:
+
+``pasteimg.nvim``
+~~~~~~~~~~~~~~~~~
+
+`pasteimg.nvim <https://github.com/daler/pasteimg.nvim>`__ supports pasting
+images to a remote system over SSH by locally converting the image to base64
+text on the clipboard.
+
+.. list-table::
+    :header-rows: 1
+    :align: left
+
+    * - command
+      - description
+
+    * - ``:PasteImgFromPayload`` on a line
+      - Converts the base64 text on the line to an image, saves it, and inserts a link to it.
+
+.. plugin-metadata::
+   :name: pasteimg
 
 .. _imgclip_ref:
 

--- a/include.file
+++ b/include.file
@@ -12,3 +12,4 @@
 .path
 .tmux.conf
 .vimrc
+.Rprofile


### PR DESCRIPTION
## R.nvim

This adds support for [R.nvim](https://github.com/R-nvim/R.nvim). 

This:
- is not required for using R (you can always use toggleterm if you want)
- adds some nice new features, but
- needs additional steps to use (`Ropen`; `nvim` and `R` must be running on the same host)

See the new docs for more.

## `attach-ipython`
This PR also adds a new function, `attach-ipython`, which lets you run IPython to debug a conda env...without needing to install IPython into that env.

## minor
And last, the dictionary source for the `blink` tab-completion plugin will only be added if the dictionary file exists. Sometimes an interactive node will not have that file, which previously would result in repeated errors but this is now fixed by enabling that source only if the file exists.